### PR TITLE
Add Post-Event Change-Check.

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/util/UtilPlaceBlocks.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/util/UtilPlaceBlocks.java
@@ -91,6 +91,9 @@ public class UtilPlaceBlocks {
       }
     }
     catch (Exception e) {
+      if(world.getBlockState(placePos).getMaterial().equals(placeState.getMaterial())){
+        return true;
+      }
       //blocked by perms or something, no need to log
       ModCyclic.logger.error("Error attempting to place block ");
       e.printStackTrace();


### PR DESCRIPTION
This patch takes care of important fixes for the placer duping blocks, the item replacer duping blocks, and the torch placer being able to place infinitely. It's not the source of the issue, but in any case for the future it will make sure if an exception has been thrown after a block has actually been placed that it will still return true so that it can be removed from the player's / machine's inventory. 

Due to the fact that at least one of these was able to be reproduced in single player without sponge, I would consider checking out what BlockState is being passed to the world. I think that the issue of the exceptions being thrown has to do with that, it is possible it could be missing some piece of information.

Have tested on single player and multiplayer and can confirm that the patch works as intended.

#549
#570 