### PR TITLE
Partial fix for desync for TileEntities with fluid tanks

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/block/hydrator/TileEntityHydrator.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/hydrator/TileEntityHydrator.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import com.lothrazar.cyclicmagic.core.block.TileEntityBaseMachineFluid;
-import com.lothrazar.cyclicmagic.core.liquid.FluidTankBase;
+import com.lothrazar.cyclicmagic.core.liquid.FluidTankFixDesync;
 import com.lothrazar.cyclicmagic.core.util.UtilItemStack;
 import com.lothrazar.cyclicmagic.gui.ITileRedstoneToggle;
 import net.minecraft.entity.player.EntityPlayer;
@@ -54,7 +54,7 @@ public class TileEntityHydrator extends TileEntityBaseMachineFluid implements IT
 
   public TileEntityHydrator() {
     super(2 * RECIPE_SIZE);// in, out 
-    tank = new FluidTankBase(TANK_FULL);
+    tank = new FluidTankFixDesync(TANK_FULL, this);
     timer = TIMER_FULL;
     tank.setTileEntity(this);
     tank.setFluidAllowed(FluidRegistry.WATER);

--- a/src/main/java/com/lothrazar/cyclicmagic/core/liquid/PacketFluidSync.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/liquid/PacketFluidSync.java
@@ -24,7 +24,7 @@
 package com.lothrazar.cyclicmagic.core.liquid;
 
 import com.lothrazar.cyclicmagic.ModCyclic;
-import com.lothrazar.cyclicmagic.block.tank.TileEntityFluidTank;
+import com.lothrazar.cyclicmagic.core.block.TileEntityBaseMachineFluid;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -77,8 +77,8 @@ public class PacketFluidSync implements IMessage, IMessageHandler<PacketFluidSyn
       EntityPlayer p = ModCyclic.proxy.getPlayerEntity(ctx);
       if (p != null) {
         TileEntity te = p.world.getTileEntity(message.pos);
-        if (te instanceof TileEntityFluidTank) {
-          ((TileEntityFluidTank) te).updateFluidTo(message.fluid);
+        if (te instanceof TileEntityBaseMachineFluid) {
+          ((TileEntityBaseMachineFluid) te).updateFluidTo(message.fluid);
         }
       }
     }


### PR DESCRIPTION
### Minecraft version & Mod Version:
Minecraft: 1.12.2
Forge: 14.23.1.2594
Cyclic: 1.15.15 (dev version of master branch commit 2605b8490eff291a7fa6617dd425681b7da1f15e)
For testing I added Pneumaticraft Repressurized 1.12.2-0.6.8-219

### Single player or Server:
Single player

### Describe problem (what you were doing / what happened):
Put down a hydrator and pump water into it through fluid transfer from other mods. In my dev environment I used the liquid hopper from Pneumaticraft but I also tried conduits from EnderIO and other mods. The hydrator gets filled with water, but the GUI still shows an empty tank. After re-logging and opening the GUI again, it shows that the internal tank actually has water in it.

### Possible Solution
I checked out the code and found, that there has already been a fix for this with the normal tank from Cyclic, since it now uses the FluidTankFixDesync class that does the network update packets. This should be used everywhere the FluidTankBase class is currently used and a GUI is involved. Furthermore the Implementation of [PacketFluidSync](https://github.com/PrinceOfAmber/Cyclic/blob/master/src/main/java/com/lothrazar/cyclicmagic/core/liquid/PacketFluidSync.java#L80) should not test for TileEntityFluidTank but for TileEntityBaseMachineFluid that already defines the update method.
I made the changes in this pull request and switched the hydrator to use the correct tank implementation. This is only a partial fix since all tile entities with GUIs should use that implementation of the tank. Maybe the FluidTankBase class shouldn't exist anymore and be merged into a common fluid tank implementation instead? 