### PR TITLE
Heart container using attributes

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
@@ -32,6 +32,8 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.passive.EntityVillager;
@@ -98,11 +100,26 @@ public class UtilEntity {
   }
 
   public static void setMaxHealth(EntityLivingBase living, double max) {
-    living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(max);
+    IAttributeInstance healthAttribute = living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
+    double amount = max - healthAttribute.getBaseValue();
+    AttributeModifier modifier = healthAttribute.getModifier(HEALTH_MODIFIER_ID);
+    // Need to remove modifier to apply a new one
+    if (modifier != null) {
+      healthAttribute.removeModifier(modifier);
+    }
+    // Operation 0 is a flat increase
+    modifier = new AttributeModifier(HEALTH_MODIFIER_ID, HEALTH_MODIFIER_NAME, amount, 0);
+    healthAttribute.applyModifier(modifier);
   }
 
   public static double getMaxHealth(EntityLivingBase living) {
-    return living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getBaseValue();
+    IAttributeInstance healthAttribute = living.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH);
+    double maxHealth = healthAttribute.getBaseValue();
+    AttributeModifier modifier = healthAttribute.getModifier(HEALTH_MODIFIER_ID);
+    if (modifier != null) {
+      maxHealth += modifier.getAmount();
+    }
+    return maxHealth;
   }
 
   public static int incrementMaxHealth(EntityLivingBase living, int by) {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
@@ -25,6 +25,7 @@ package com.lothrazar.cyclicmagic.core.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import com.lothrazar.cyclicmagic.ModCyclic;
 import com.lothrazar.cyclicmagic.core.data.Vector3;
 import com.lothrazar.cyclicmagic.net.PacketPlayerFalldamage;
@@ -56,6 +57,8 @@ public class UtilEntity {
 
   private static final double ENTITY_PULL_DIST = 0.4;//closer than this and nothing happens
   private static final double ENTITY_PULL_SPEED_CUTOFF = 3;//closer than this and it slows down
+  public static final UUID HEALTH_MODIFIER_ID = UUID.fromString("60b1b9b5-dc5d-43a2-aa4e-655353070dbe");
+  public static final String HEALTH_MODIFIER_NAME = "Cyclic Health Modifier";
   private final static float ITEMSPEEDFAR = 0.9F;
   private final static float ITEMSPEEDCLOSE = 0.2F;
 


### PR DESCRIPTION
## Minecraft version & Mod Version:
Minecraft: 1.12.2
Forge: 14.23.4.2727
Cyclic: 1.12.2-1.15.16 (changes based on https://github.com/PrinceOfAmber/Cyclic/commit/d49bf8f7f07b991e5e59812340411293488ae625)
### Mods that change health:
Botania: r1.10-354
Nutrition: 1.12.2-3.4.0
ScalingHealth: 1.12-1.3.18-101
solcarrot: 1.12.2-1.3.3
### Supporting mods in test profile:
AppleCore: mc1.12.2-3.1.3
Baubles: 1.12-1.5.2
CraftTweaker2: 1.12-4.1.9
Just Enough Items: 1.12.2-4.11.0.202
SilentLib: 1.12-2.2.18-100

## Single player or Server:
Both are affected

## Describe problem (what you were doing / what happened):
Cyclic heart canisters do not stack properly with other mods that modify health.
Especially apparant with Scaling Health, it also has a feature that changes starting health similar to starting heart canisters like Cyclic.

The cause of this is using setBaseValue on the health attribute. This would conflict with mods that either change the base value or base calculations on it in an incompatible way.
In Scaling Health's case it [calculates bonus health based on getBaseValue](https://github.com/SilentChaos512/ScalingHealth/blob/0587db0053df5f822eb1f1f061bdef6587ef8334/common/net/silentchaos512/scalinghealth/utils/ModifierHandler.java#L29) to work out what its modifier should be to adjust the starting health (starting health - base health + bonus health).

## Potential Solutions and Notes
### Least disruptive change (the one currently being PR'ed):
Modify the `UtilEntity.setMaxHealth` and `UtilEntity.getMaxHealth` to use an AttributeModifier instead of setBaseValue.
[Here is a video with these changes](https://youtu.be/_JkuL08YvI4)

### Change to being bonus health insted of max health:
This would involve updating Cyclic's player data store, in addition we should also make the health boost source the heart container itself so that in the future.
This change can be applied after the previous suggested change, if you make use of the same UUID but have it for the heart canisters it will replace it.
This is is not crucial if no plans for other methods to increase in the future, and might not be required if cyclic internally uses just a single attribute modifiers but collects the absolute modifier itself from the sources in the mod and they're all flat changes.

For reference the "operation" part of modifiers, I couldn't find it documented anywhere, but here's what the effect seems to be:

0 - Flat increase (+X)
1 - Additive Percentage increase (+X%)
2 - Multiplicative Percentage increase ((1+X)%)

`RESULT = (BASE + SUM(T0_i)) * (1 + SUM(T1_i) * PRODUCT(1 + T2_i)`

## Related Issues
https://github.com/PrinceOfAmber/Cyclic/issues/614 (Original Issue)
https://github.com/PrinceOfAmber/Cyclic/issues/785 (Duplicate)
https://github.com/PrinceOfAmber/Cyclic/issues/833 (Semi-related, the root cause is similar)

## Original
<details>
<summary>Click to expand</summary>
Dear PrinceOfAmber,

This is a minimal change that allows Cyclic's health modifier to be compatible with other mods that also affect health, by making use of attribute modifiers.

The downsides to this change is get/setMaxHealth being a misnomer since it'll be ignoring the health boosts from other mods, so it's really get/setBaseHealthPlusBonusCyclicHealth. In essence it's quite the bandaid fix, but also the least intrusive one.

Idealy there would be an attribute modifier for each source, so if cyclic were to add other health attribute modifiers in the future they would stack properly.

When first assessing potential changes, identified that it would be quite the intrusive change if this were to be changed from maxHealth to being bonusHealthFromHeartCanisters. It would involve making a breaking change to the Cyclic player data, which currently stores the maxHealth. This field would need to be changed, perhaps adding a "version" field to the cyclic player data would be a good way to keep track of the version of the player data, this way you could have the player data be updated by maintaining a method to update old player data in case of such breaking changes in the future.

This pull request is really opening the discussion, very interested to hear about what your thoughts on this are.

Regards,
BlueAgent
</details>
