### PR TITLE
Add FastBench compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ minecraft {
 
 
     version = "${mc_version}-${forge_version}"
-    mappings = "snapshot_20170624"
+    mappings = "stable_39"
     runDir = "run"
     makeObfSourceJar = false
     useDepAts = true
@@ -92,10 +92,9 @@ repositories {
 dependencies {
   deobfCompile "mezz.jei:jei_${mc_version}:+"
   deobfCompile "mcp.mobius.waila:Hwyla:+"
-  deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+"
-  deobfCompile "baubles:Baubles:1.12:1.5.2"
-  deobfCompile "fastworkbench:FastWorkbench:1.12.2:1.5.2"
-  deobfCompile name: "Baubles", version: "${baubles_version}"
+  deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:${crt_version}"
+  deobfCompile "baubles:Baubles:1.12:${baubles_version}"
+  deobfCompile "fastworkbench:FastWorkbench:${mc_version}:${fb_version}"
   deobfCompile "info.amerifrance.guideapi:Guide-API:${guideapi_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,15 @@ build.dependsOn signJar
 //Defines basic patterns for pulling various dependencies.
 repositories {
     maven {
+        url "http://dvs1.progwml6.com/files/maven"
+    }
+    maven {
+		url 'http://maven.blamejared.com'
+	}
+	maven {
+        url = "http://minecraft.curseforge.com/api/maven/"
+    }
+    maven {
     	name = "Progwml6 maven"
         url "http://dvs1.progwml6.com/files/maven"
     }
@@ -81,18 +90,12 @@ repositories {
 }
 
 dependencies {
-
-  // compile against the JEI API
-  // deobfCompile "mezz.jei:jei_${mc_version}:${jei_version}:api"
-  // at runtime, use the full JEI jar
-  // runtime "mezz.jei:jei_${mc_version}:${jei_version}"
-
-  //compile files("lib/Baubles-${baubles_version}.jar")
-  
+  deobfCompile "mezz.jei:jei_${mc_version}:+"
+  deobfCompile "mcp.mobius.waila:Hwyla:+"
+  deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+"
+  deobfCompile "baubles:Baubles:1.12:1.5.2"
+  deobfCompile "fastworkbench:FastWorkbench:1.12.2:1.5.2"
   deobfCompile name: "Baubles", version: "${baubles_version}"
-  
-  
-  
   deobfCompile "info.amerifrance.guideapi:Guide-API:${guideapi_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 # RENAME this to gradle.properties after cloning the repo, if the original is missing
 org.gradle.jvmargs=-Xmx3G
-forge_version=14.23.4.2705
+forge_version=14.23.4.2760
 mc_version=1.12.2
 mod_version=1.17.0
 baubles_version=1.5.2
 guideapi_version=1.12-2.1.3-55
 crt_version=1.12-4.1.9.478
-fb_version=1.5.2
+fb_version=1.5.3
 
 # jar signing https://tutorials.darkhax.net/tutorials/jar_signing/

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,9 @@ org.gradle.jvmargs=-Xmx3G
 forge_version=14.23.4.2705
 mc_version=1.12.2
 mod_version=1.17.0
-baubles_version=1.12-1.4.5
+baubles_version=1.5.2
 guideapi_version=1.12-2.1.3-55
+crt_version=1.12-4.1.9.478
+fb_version=1.5.2
 
 # jar signing https://tutorials.darkhax.net/tutorials/jar_signing/

--- a/src/main/java/com/lothrazar/cyclicmagic/ModCyclic.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/ModCyclic.java
@@ -67,7 +67,7 @@ import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 
-@Mod(modid = Const.MODID, useMetadata = true, dependencies = "before:guideapi;after:jei;after:baubles;after:crafttweaker;after:fastbench", canBeDeactivated = false, certificateFingerprint = "@FINGERPRINT@", updateJSON = "https://raw.githubusercontent.com/PrinceOfAmber/CyclicMagic/master/update.json", acceptableRemoteVersions = "*", acceptedMinecraftVersions = "[1.12,)", guiFactory = "com.lothrazar." + Const.MODID + ".config.IngameConfigFactory")
+@Mod(modid = Const.MODID, useMetadata = true, dependencies = "before:guideapi;after:jei;after:baubles;after:crafttweaker;after:fastbench@[1.5.3,)", canBeDeactivated = false, certificateFingerprint = "@FINGERPRINT@", updateJSON = "https://raw.githubusercontent.com/PrinceOfAmber/CyclicMagic/master/update.json", acceptableRemoteVersions = "*", acceptedMinecraftVersions = "[1.12,)", guiFactory = "com.lothrazar." + Const.MODID + ".config.IngameConfigFactory")
 public class ModCyclic {
 
   @Instance(value = Const.MODID)

--- a/src/main/java/com/lothrazar/cyclicmagic/ModCyclic.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/ModCyclic.java
@@ -67,7 +67,7 @@ import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 
-@Mod(modid = Const.MODID, useMetadata = true, dependencies = "before:guideapi;after:jei;after:baubles,crafttweaker", canBeDeactivated = false, certificateFingerprint = "@FINGERPRINT@", updateJSON = "https://raw.githubusercontent.com/PrinceOfAmber/CyclicMagic/master/update.json", acceptableRemoteVersions = "*", acceptedMinecraftVersions = "[1.12,)", guiFactory = "com.lothrazar." + Const.MODID + ".config.IngameConfigFactory")
+@Mod(modid = Const.MODID, useMetadata = true, dependencies = "before:guideapi;after:jei;after:baubles;after:crafttweaker;after:fastbench", canBeDeactivated = false, certificateFingerprint = "@FINGERPRINT@", updateJSON = "https://raw.githubusercontent.com/PrinceOfAmber/CyclicMagic/master/update.json", acceptableRemoteVersions = "*", acceptedMinecraftVersions = "[1.12,)", guiFactory = "com.lothrazar." + Const.MODID + ".config.IngameConfigFactory")
 public class ModCyclic {
 
   @Instance(value = Const.MODID)

--- a/src/main/java/com/lothrazar/cyclicmagic/block/BlockLaunch.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/BlockLaunch.java
@@ -83,7 +83,7 @@ public class BlockLaunch extends BlockBaseFlat implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     if (sneakPlayerAvoid && entity instanceof EntityPlayer && ((EntityPlayer) entity).isSneaking()) {
       return;
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/BlockShears.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/BlockShears.java
@@ -68,7 +68,7 @@ public class BlockShears extends BlockBase implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World world, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World world, BlockPos pos, IBlockState state, Entity entity) {
     if (entity instanceof IShearable) {
       IShearable sheep = (IShearable) entity;
       ItemStack fake = new ItemStack(Items.SHEARS);

--- a/src/main/java/com/lothrazar/cyclicmagic/block/BlockSpikesRetractable.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/BlockSpikesRetractable.java
@@ -88,7 +88,7 @@ public class BlockSpikesRetractable extends BlockBase implements IHasRecipe, IHa
 
   //copy vanilla methods: 8 facing directions bitwise-combined with enabled or not
   public static EnumFacing getFacing(int meta) {
-    return EnumFacing.getFront(meta & 7);
+    return EnumFacing.byIndex(meta & 7);
   }
 
   public static EnumFacing getFacing(IBlockState state) {
@@ -131,7 +131,7 @@ public class BlockSpikesRetractable extends BlockBase implements IHasRecipe, IHa
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     if (entity instanceof EntityLivingBase && worldIn.getBlockState(pos).getValue(ACTIVATED)) {
       if (this.doesPlayerDamage) {
         if (worldIn instanceof WorldServer) {

--- a/src/main/java/com/lothrazar/cyclicmagic/block/applesprout/BlockAppleCrop.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/applesprout/BlockAppleCrop.java
@@ -171,7 +171,7 @@ public class BlockAppleCrop extends BlockBase implements IGrowable, IHasRecipe, 
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.CUTOUT;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/arrowtarget/BlockArrowTarget.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/arrowtarget/BlockArrowTarget.java
@@ -82,8 +82,8 @@ public class BlockArrowTarget extends BlockBaseHasTile implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World world, BlockPos pos, IBlockState state, Entity entity) {
-    super.onEntityCollidedWithBlock(world, pos, state, entity);
+  public void onEntityCollision(World world, BlockPos pos, IBlockState state, Entity entity) {
+    super.onEntityCollision(world, pos, state, entity);
     //ignore vertical sides.
     double x = entity.posX - pos.getX();
     double z = entity.posZ - pos.getZ();

--- a/src/main/java/com/lothrazar/cyclicmagic/block/bean/BlockCropMagicBean.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/bean/BlockCropMagicBean.java
@@ -205,7 +205,7 @@ public class BlockCropMagicBean extends BlockCrops implements IHasConfig {
       if (drop == null || drop.getItem() == null) {
         continue;
       }
-      String resource = drop.getItem().getRegistryName().getResourceDomain() + ":" + drop.getItem().getRegistryName().getResourcePath();
+      String resource = drop.getItem().getRegistryName().getNamespace() + ":" + drop.getItem().getRegistryName().getPath();
       if (drop.getMetadata() > 0) {
         resource += "*" + drop.getMetadata();
       }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/buttondoorbell/BlockDoorbell.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/buttondoorbell/BlockDoorbell.java
@@ -62,7 +62,7 @@ public class BlockDoorbell extends BlockButton implements IHasRecipe {
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/block/buttonflat/BlockButtonLarge.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/buttonflat/BlockButtonLarge.java
@@ -55,7 +55,7 @@ public class BlockButtonLarge extends BlockButton implements IHasRecipe {
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/block/cable/BlockCableBase.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/cable/BlockCableBase.java
@@ -300,7 +300,7 @@ public abstract class BlockCableBase extends BlockBaseHasTile {
     for (AxisAlignedBB box : boxes) {
       RayTraceResult result = box.calculateIntercept(a, b);
       if (result != null) {
-        Vec3d vec = result.hitVec.addVector(x, y, z);
+        Vec3d vec = result.hitVec.add(x, y, z);
         results.add(new RayTraceResult(vec,
             result.sideHit, pos));
       }
@@ -319,7 +319,7 @@ public abstract class BlockCableBase extends BlockBaseHasTile {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.CUTOUT_MIPPED;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyor.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyor.java
@@ -166,7 +166,7 @@ public class BlockConveyor extends BlockBaseFlat implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     if (sneakPlayerAvoid && entity instanceof EntityPlayer && ((EntityPlayer) entity).isSneaking()) {
       return;
     }
@@ -279,7 +279,7 @@ public class BlockConveyor extends BlockBaseFlat implements IHasRecipe {
   //below is all for facing
   @Override
   public IBlockState getStateFromMeta(int meta) {
-    EnumFacing facing = EnumFacing.getHorizontal(meta);
+    EnumFacing facing = EnumFacing.byHorizontalIndex(meta);
     return this.getDefaultState().withProperty(PROPERTYFACING, facing);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyorAngle.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyorAngle.java
@@ -111,6 +111,7 @@ public class BlockConveyorAngle extends BlockConveyor implements IHasRecipe {
   }
 
   @Override
+  @Deprecated
   public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean p_185477_7_) {
     final double heightInc = 0.0125D;
     final double sideInc = heightInc;
@@ -154,7 +155,7 @@ public class BlockConveyorAngle extends BlockConveyor implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     if (sneakPlayerAvoid && entity instanceof EntityPlayer && ((EntityPlayer) entity).isSneaking()) {
       return;
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyorCorner.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/conveyor/BlockConveyorCorner.java
@@ -41,7 +41,7 @@ public class BlockConveyorCorner extends BlockConveyor {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     EnumFacing face = getFacingFromState(state);
     if (state.getValue(FLIPPED)) {
       face = face.getOpposite();

--- a/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/BlockDeHydrator.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/BlockDeHydrator.java
@@ -65,7 +65,7 @@ public class BlockDeHydrator extends BlockBaseFacing implements IHasConfig, IHas
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.CUTOUT;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/GuiDeHydrator.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/GuiDeHydrator.java
@@ -53,7 +53,7 @@ public class GuiDeHydrator extends GuiBaseContainer {
   @Override
   public void initGui() {
     super.initGui();
-    int btnId = 3;
+    //    int btnId = 3;
     //    btnToggle = new ButtonTileEntityField(btnId++,
     //        this.guiLeft + 26,
     //        this.guiTop + Const.PAD / 2, this.tile.getPos(), TileEntityDeHydrator.Fields.RECIPELOCKED.ordinal());

--- a/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/RecipeDeHydrate.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/dehydrator/RecipeDeHydrate.java
@@ -49,7 +49,7 @@ public class RecipeDeHydrate extends IForgeRegistryEntry.Impl<IRecipe> implement
     recipeInput = in;
     resultItem = out;
     this.time = time;
-    this.setRegistryName(new ResourceLocation(Const.MODID, "dehydrate" + UUID.randomUUID().toString() + out.getUnlocalizedName()));
+    this.setRegistryName(new ResourceLocation(Const.MODID, "dehydrate" + UUID.randomUUID().toString() + out.getTranslationKey()));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireBase.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireBase.java
@@ -51,7 +51,7 @@ public class BlockFireBase extends BlockFire {
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override
@@ -110,7 +110,7 @@ public class BlockFireBase extends BlockFire {
                 BlockPos blockpos = pos.add(k, i1, l);
                 int k1 = this.getNeighborEncouragement(worldIn, blockpos);
                 if (k1 > 0) {
-                  int l1 = (k1 + 40 + worldIn.getDifficulty().getDifficultyId() * 7) / (intAge + 30);
+                  int l1 = (k1 + 40 + worldIn.getDifficulty().getId() * 7) / (intAge + 30);
                   if (isHumid) {
                     l1 /= 2;
                   }
@@ -164,7 +164,7 @@ public class BlockFireBase extends BlockFire {
         worldIn.setBlockState(pos, this.getDefaultState().withProperty(AGE, Integer.valueOf(j)), 3);
       }
       if (iblockstate.getBlock() == Blocks.TNT) {
-        Blocks.TNT.onBlockDestroyedByPlayer(worldIn, pos, iblockstate.withProperty(BlockTNT.EXPLODE, Boolean.valueOf(true)));
+        Blocks.TNT.onPlayerDestroy(worldIn, pos, iblockstate.withProperty(BlockTNT.EXPLODE, Boolean.valueOf(true)));
       }
     }
   }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireFrost.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireFrost.java
@@ -42,7 +42,7 @@ public class BlockFireFrost extends BlockFireBase {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
     if (!worldIn.isRemote && entityIn instanceof EntityLivingBase) {
       EntityLivingBase e = ((EntityLivingBase) entityIn);
       if (!e.isPotionActive(MobEffects.SLOWNESS)) {
@@ -53,6 +53,6 @@ public class BlockFireFrost extends BlockFireBase {
         e.addPotionEffect(new PotionEffect(MobEffects.SLOWNESS, Const.TICKS_PER_SEC * 10, Const.Potions.II));
       }
     }
-    super.onEntityCollidedWithBlock(worldIn, pos, state, entityIn);
+    super.onEntityCollision(worldIn, pos, state, entityIn);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireSafe.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/fire/BlockFireSafe.java
@@ -41,7 +41,7 @@ public class BlockFireSafe extends BlockFireBase {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
     if (!worldIn.isRemote && entityIn instanceof EntityLivingBase
         && !(entityIn instanceof EntityPlayer)) {
       EntityLivingBase e = ((EntityLivingBase) entityIn);
@@ -50,6 +50,6 @@ public class BlockFireSafe extends BlockFireBase {
         e.setFire(FIRESECONDS);
       }
     }
-    super.onEntityCollidedWithBlock(worldIn, pos, state, entityIn);
+    super.onEntityCollision(worldIn, pos, state, entityIn);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/forester/TileEntityForester.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/forester/TileEntityForester.java
@@ -100,7 +100,7 @@ public class TileEntityForester extends TileEntityBaseMachineInvo implements ITi
 
   private void verifyFakePlayer(WorldServer w) {
     if (fakePlayer == null) {
-      fakePlayer = UtilFakePlayer.initFakePlayer(w, this.uuid, this.getBlockType().getUnlocalizedName());
+      fakePlayer = UtilFakePlayer.initFakePlayer(w, this.uuid, this.getBlockType().getTranslationKey());
       if (fakePlayer == null) {
         ModCyclic.logger.error("Fake player failed to init ");
       }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/hydrator/RecipeHydrate.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/hydrator/RecipeHydrate.java
@@ -68,7 +68,7 @@ public class RecipeHydrate extends IForgeRegistryEntry.Impl<IRecipe> implements 
     }
     this.fluidCost = w;
     this.resultItem = out;
-    this.setRegistryName(new ResourceLocation(Const.MODID, "hydrator_" + UUID.randomUUID().toString() + out.getUnlocalizedName()));
+    this.setRegistryName(new ResourceLocation(Const.MODID, "hydrator_" + UUID.randomUUID().toString() + out.getTranslationKey()));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/block/ore/BlockDimensionOre.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/ore/BlockDimensionOre.java
@@ -181,7 +181,7 @@ public class BlockDimensionOre extends BlockOre implements IHasOreDict {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.CUTOUT;
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/packager/RecipePackage.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/packager/RecipePackage.java
@@ -36,7 +36,7 @@ public class RecipePackage extends IForgeRegistryEntry.Impl<IRecipe> implements 
         input.set(i, in[i]);
     }
     output = out;
-    this.setRegistryName(new ResourceLocation(Const.MODID, "packager" + UUID.randomUUID().toString() + out.getUnlocalizedName()));
+    this.setRegistryName(new ResourceLocation(Const.MODID, "packager" + UUID.randomUUID().toString() + out.getTranslationKey()));
   }
 
   public NonNullList<ItemStack> getInput() {

--- a/src/main/java/com/lothrazar/cyclicmagic/block/password/BlockPassword.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/password/BlockPassword.java
@@ -137,9 +137,9 @@ public class BlockPassword extends BlockBaseHasTile implements IHasRecipe {
     if (wasFound > 0) {
       event.setCanceled(true);//If this event is canceled, the chat message is never distributed to all clients.
       if (wasFound == 1)
-        UtilChat.addChatMessage(event.getPlayer(), UtilChat.lang(this.getUnlocalizedName() + ".triggered") + event.getMessage());
+        UtilChat.addChatMessage(event.getPlayer(), UtilChat.lang(this.getTranslationKey() + ".triggered") + event.getMessage());
       else
-        UtilChat.addChatMessage(event.getPlayer(), wasFound + " " + UtilChat.lang(this.getUnlocalizedName() + ".triggeredmany") + event.getMessage());
+        UtilChat.addChatMessage(event.getPlayer(), wasFound + " " + UtilChat.lang(this.getTranslationKey() + ".triggeredmany") + event.getMessage());
     }
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/password/GuiPassword.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/password/GuiPassword.java
@@ -52,7 +52,7 @@ public class GuiPassword extends GuiBaseContainer {
     super(new ContainerPassword(tileEntity), tileEntity);
     ctr = (ContainerPassword) this.inventorySlots;
     this.ySize = 79;//texture size in pixels
-    namePref = tileEntity.getBlockType().getUnlocalizedName() + ".";
+    namePref = tileEntity.getBlockType().getTranslationKey() + ".";
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/block/placer/TileEntityPlacer.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/placer/TileEntityPlacer.java
@@ -125,7 +125,7 @@ public class TileEntityPlacer extends TileEntityBaseMachineInvo implements ITile
 
   private void verifyFakePlayer(WorldServer w) {
     if (fakePlayer == null) {
-      fakePlayer = UtilFakePlayer.initFakePlayer(w, this.uuid, this.getBlockType().getUnlocalizedName());
+      fakePlayer = UtilFakePlayer.initFakePlayer(w, this.uuid, this.getBlockType().getTranslationKey());
       if (fakePlayer == null) {
         ModCyclic.logger.error("Fake player failed to init ");
       }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/scaffolding/BlockScaffolding.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/scaffolding/BlockScaffolding.java
@@ -81,7 +81,7 @@ public class BlockScaffolding extends BlockBase implements IHasRecipe {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.CUTOUT;
   }
 
@@ -108,12 +108,12 @@ public class BlockScaffolding extends BlockBase implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
     if (!(entityIn instanceof EntityLivingBase)) {
       return;
     }
     EntityLivingBase entity = (EntityLivingBase) entityIn;
-    if (!entityIn.isCollidedHorizontally) {
+    if (!entityIn.collidedHorizontally) {
       return;
     }
     UtilEntity.tryMakeEntityClimb(worldIn, entity, CLIMB_SPEED);

--- a/src/main/java/com/lothrazar/cyclicmagic/block/screen/BlockScreen.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/screen/BlockScreen.java
@@ -60,7 +60,7 @@ public class BlockScreen extends BlockBaseFacing implements IBlockHasTESR, IHasR
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.SOLID;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/sprinkler/BlockSprinkler.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/sprinkler/BlockSprinkler.java
@@ -86,11 +86,11 @@ public class BlockSprinkler extends BlockBaseHasTile implements IBlockHasTESR, I
   public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
     TileSprinkler te = (TileSprinkler) world.getTileEntity(pos);
     if (te.isRunning() == false) { //inform player water is needed
-      UtilChat.sendStatusMessage(player, UtilChat.lang(this.getUnlocalizedName() + ".empty"));
+      UtilChat.sendStatusMessage(player, UtilChat.lang(this.getTranslationKey() + ".empty"));
     }
     if (player.isSneaking()) {
       te.toggleSpawnParticles();
-      UtilChat.sendStatusMessage(player, UtilChat.lang(this.getUnlocalizedName() + ".particles." + te.isSpawningParticles()));
+      UtilChat.sendStatusMessage(player, UtilChat.lang(this.getTranslationKey() + ".particles." + te.isSpawningParticles()));
     }
     return super.onBlockActivated(world, pos, state, player, hand, side, hitX, hitY, hitZ);
   }

--- a/src/main/java/com/lothrazar/cyclicmagic/block/tank/BlockFluidTank.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/tank/BlockFluidTank.java
@@ -133,7 +133,7 @@ public class BlockFluidTank extends BlockBase implements ITileEntityProvider, IH
 
   @SideOnly(Side.CLIENT)
   @Override
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.TRANSLUCENT; // http://www.minecraftforge.net/forum/index.php?topic=18754.0
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/vector/BlockVectorPlate.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/vector/BlockVectorPlate.java
@@ -92,7 +92,7 @@ public class BlockVectorPlate extends BlockBaseHasTile implements IHasRecipe {
   }
 
   @Override
-  public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
+  public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entity) {
     int yFloor = MathHelper.floor(entity.posY);
     double posWithinBlock = entity.posY - yFloor;
     TileEntityVector tile = (TileEntityVector) worldIn.getTileEntity(pos);
@@ -228,7 +228,7 @@ public class BlockVectorPlate extends BlockBaseHasTile implements IHasRecipe {
   //END OF ITEMBLOCK DATA
   @SideOnly(Side.CLIENT)
   @Override
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.TRANSLUCENT;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/block/wireless/ItemBlockWireless.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/wireless/ItemBlockWireless.java
@@ -52,6 +52,6 @@ public class ItemBlockWireless extends ItemBlock {
         return;
       }
     }
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastPlayerBench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastPlayerBench.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import javax.annotation.Nullable;
+
+import com.lothrazar.cyclicmagic.playerupgrade.crafting.InventoryPlayerExtWorkbench;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.inventory.InventoryCraftResult;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import shadows.fastbench.gui.ClientContainerFastBench;
+import shadows.fastbench.gui.SlotCraftingSucks;
+
+public class ClientContainerFastPlayerBench extends ClientContainerFastBench {
+
+	private static final EntityEquipmentSlot[] ARMOR = new EntityEquipmentSlot[] { EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET };
+	public static final int SLOT_SHIELD = 40;
+	public static final int SQ = 18;
+	public static final int VROW = 3;
+	public static final int VCOL = 9;
+	public static final int HOTBAR_SIZE = 9;
+	final int pad = 8;
+	EntityPlayer player;
+
+	public ClientContainerFastPlayerBench(EntityPlayer player, World world) {
+		super(player, world, 0, 0, 0);
+		this.player = player;
+		int xResult = 155, yResult = 22;
+		this.inventorySlots.clear();
+		this.inventoryItemStacks.clear();
+		int xPos, yPos;
+
+		this.addSlotToContainer(new SlotCraftingSucks(this, player, craftMatrix, craftResult, 0, xResult, yResult));
+
+		for (int i = 0; i < InventoryPlayerExtWorkbench.IROW; ++i) {
+			for (int j = 0; j < InventoryPlayerExtWorkbench.ICOL; ++j) {
+				xPos = (j + 1) * SQ + 65;
+				yPos = i * SQ + 6;
+				this.addSlotToContainer(new Slot(craftMatrix, j + i * 3, xPos, yPos));
+			}
+		}
+
+		for (int k = 0; k < 3; ++k) {
+			for (int i1 = 0; i1 < 9; ++i1) {
+				this.addSlotToContainer(new Slot(player.inventory, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
+			}
+		}
+
+		for (int l = 0; l < 9; ++l) {
+			this.addSlotToContainer(new Slot(player.inventory, l, 8 + l * 18, 142));
+		}
+
+		for (int k = 0; k < ARMOR.length; k++) {
+			final EntityEquipmentSlot slot = ARMOR[k];
+			this.addSlotToContainer(new Slot(player.inventory, 36 + (3 - k), pad, pad + k * SQ) {
+
+				@Override
+				public int getSlotStackLimit() {
+					return 1;
+				}
+
+				@Override
+				public boolean isItemValid(ItemStack stack) {
+					return !stack.isEmpty() && stack.getItem().isValidArmor(stack, slot, player);
+				}
+
+				@Override
+				public String getSlotTexture() {
+					return ItemArmor.EMPTY_SLOT_NAMES[slot.getIndex()];
+				}
+			});
+		}
+
+		this.addSlotToContainer(new Slot(player.inventory, 40, 77, 62) {
+
+			@Override
+			public boolean isItemValid(@Nullable ItemStack stack) {
+				return super.isItemValid(stack);
+			}
+
+			@Override
+			public String getSlotTexture() {
+				return "minecraft:items/empty_armor_slot_shield";
+			}
+		});
+	}
+
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
+
+		if (slot != null && slot.getHasStack()) {
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+
+			if (index == 0) {
+				itemstack1.getItem().onCreated(itemstack1, playerIn.world, playerIn);
+				if (!this.mergeItemStack(itemstack1, 10, 46, true)) return ItemStack.EMPTY;
+				slot.onSlotChange(itemstack1, itemstack);
+
+			} else if (index >= 10 && index < 37) {
+				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 37, 46, false))) return ItemStack.EMPTY;
+
+			} else if (index >= 37 && index < 46) {
+				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 10, 37, false))) return ItemStack.EMPTY;
+
+			} else if (!this.mergeItemStack(itemstack1, 10, 46, false)) return ItemStack.EMPTY;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) return ItemStack.EMPTY;
+
+			ItemStack itemstack2 = slot.onTake(playerIn, itemstack1);
+
+			if (index == 0) {
+				playerIn.dropItem(itemstack2, false);
+			}
+		}
+
+		return itemstack;
+	}
+
+	@Override
+	protected void slotChangedCraftingGrid(World world, EntityPlayer player, InventoryCrafting inv, InventoryCraftResult result) {
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer playerIn) {
+		return true;
+	}
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastPlayerBench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastPlayerBench.java
@@ -23,141 +23,18 @@
  ******************************************************************************/
 package com.lothrazar.cyclicmagic.compat.fastbench;
 
-import javax.annotation.Nullable;
-
-import com.lothrazar.cyclicmagic.playerupgrade.crafting.InventoryPlayerExtWorkbench;
-
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.inventory.Slot;
-import net.minecraft.item.ItemArmor;
-import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
-import shadows.fastbench.gui.ClientContainerFastBench;
-import shadows.fastbench.gui.SlotCraftingSucks;
 
-public class ClientContainerFastPlayerBench extends ClientContainerFastBench {
-
-	private static final EntityEquipmentSlot[] ARMOR = new EntityEquipmentSlot[] { EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET };
-	public static final int SLOT_SHIELD = 40;
-	public static final int SQ = 18;
-	public static final int VROW = 3;
-	public static final int VCOL = 9;
-	public static final int HOTBAR_SIZE = 9;
-	final int pad = 8;
-	EntityPlayer player;
+public class ClientContainerFastPlayerBench extends ContainerFastPlayerBench {
 
 	public ClientContainerFastPlayerBench(EntityPlayer player, World world) {
-		super(player, world, 0, 0, 0);
-		this.player = player;
-		int xResult = 155, yResult = 22;
-		this.inventorySlots.clear();
-		this.inventoryItemStacks.clear();
-		int xPos, yPos;
-
-		this.addSlotToContainer(new SlotCraftingSucks(this, player, craftMatrix, craftResult, 0, xResult, yResult));
-
-		for (int i = 0; i < InventoryPlayerExtWorkbench.IROW; ++i) {
-			for (int j = 0; j < InventoryPlayerExtWorkbench.ICOL; ++j) {
-				xPos = (j + 1) * SQ + 65;
-				yPos = i * SQ + 6;
-				this.addSlotToContainer(new Slot(craftMatrix, j + i * 3, xPos, yPos));
-			}
-		}
-
-		for (int k = 0; k < 3; ++k) {
-			for (int i1 = 0; i1 < 9; ++i1) {
-				this.addSlotToContainer(new Slot(player.inventory, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
-			}
-		}
-
-		for (int l = 0; l < 9; ++l) {
-			this.addSlotToContainer(new Slot(player.inventory, l, 8 + l * 18, 142));
-		}
-
-		for (int k = 0; k < ARMOR.length; k++) {
-			final EntityEquipmentSlot slot = ARMOR[k];
-			this.addSlotToContainer(new Slot(player.inventory, 36 + (3 - k), pad, pad + k * SQ) {
-
-				@Override
-				public int getSlotStackLimit() {
-					return 1;
-				}
-
-				@Override
-				public boolean isItemValid(ItemStack stack) {
-					return !stack.isEmpty() && stack.getItem().isValidArmor(stack, slot, player);
-				}
-
-				@Override
-				public String getSlotTexture() {
-					return ItemArmor.EMPTY_SLOT_NAMES[slot.getIndex()];
-				}
-			});
-		}
-
-		this.addSlotToContainer(new Slot(player.inventory, 40, 77, 62) {
-
-			@Override
-			public boolean isItemValid(@Nullable ItemStack stack) {
-				return super.isItemValid(stack);
-			}
-
-			@Override
-			public String getSlotTexture() {
-				return "minecraft:items/empty_armor_slot_shield";
-			}
-		});
-	}
-
-	@Override
-	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
-		ItemStack itemstack = ItemStack.EMPTY;
-		Slot slot = this.inventorySlots.get(index);
-
-		if (slot != null && slot.getHasStack()) {
-			ItemStack itemstack1 = slot.getStack();
-			itemstack = itemstack1.copy();
-
-			if (index == 0) {
-				itemstack1.getItem().onCreated(itemstack1, playerIn.world, playerIn);
-				if (!this.mergeItemStack(itemstack1, 10, 46, true)) return ItemStack.EMPTY;
-				slot.onSlotChange(itemstack1, itemstack);
-
-			} else if (index >= 10 && index < 37) {
-				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 37, 46, false))) return ItemStack.EMPTY;
-
-			} else if (index >= 37 && index < 46) {
-				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 10, 37, false))) return ItemStack.EMPTY;
-
-			} else if (!this.mergeItemStack(itemstack1, 10, 46, false)) return ItemStack.EMPTY;
-
-			if (itemstack1.isEmpty()) {
-				slot.putStack(ItemStack.EMPTY);
-			} else {
-				slot.onSlotChanged();
-			}
-
-			if (itemstack1.getCount() == itemstack.getCount()) return ItemStack.EMPTY;
-
-			ItemStack itemstack2 = slot.onTake(playerIn, itemstack1);
-
-			if (index == 0) {
-				playerIn.dropItem(itemstack2, false);
-			}
-		}
-
-		return itemstack;
+		super(player, world);
 	}
 
 	@Override
 	protected void slotChangedCraftingGrid(World world, EntityPlayer player, InventoryCrafting inv, InventoryCraftResult result) {
-	}
-
-	@Override
-	public boolean canInteractWith(EntityPlayer playerIn) {
-		return true;
 	}
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastWorkbench.java
@@ -1,0 +1,55 @@
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import com.lothrazar.cyclicmagic.block.workbench.InventoryWorkbench;
+import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
+import com.lothrazar.cyclicmagic.core.util.Const;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryCraftResult;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.inventory.Slot;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import shadows.fastbench.gui.ClientContainerFastBench;
+import shadows.fastbench.gui.SlotCraftingSucks;
+
+public class ClientContainerFastWorkbench extends ClientContainerFastBench {
+
+	static Block workbench = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Const.MODID, "block_workbench"));
+
+	final TileEntityWorkbench te;
+
+	public ClientContainerFastWorkbench(EntityPlayer player, World world, TileEntityWorkbench te) {
+		super(player, world, te.getPos().getX(), te.getPos().getY(), te.getPos().getZ());
+		this.te = te;
+		this.craftMatrix = new InventoryWorkbench(this, te);
+		int x = 0;
+		replaceSlot(x++, new SlotCraftingSucks(this, player, this.craftMatrix, this.craftResult, 0, 124, 35));
+		for (int i = 0; i < 3; ++i) {
+			for (int j = 0; j < 3; ++j) {
+				replaceSlot(x++, new Slot(this.craftMatrix, j + i * 3, 30 + j * 18, 17 + i * 18));
+			}
+		}
+	}
+
+	void replaceSlot(int num, Slot slotIn) {
+		slotIn.slotNumber = num;
+		this.inventorySlots.set(num, slotIn);
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer playerIn) {
+		if (te.getWorld().getBlockState(te.getPos()).getBlock() != workbench) {
+			return false;
+		} else {
+			return playerIn.getDistanceSq(te.getPos().getX() + 0.5D, te.getPos().getY() + 0.5D, te.getPos().getZ() + 0.5D) <= 64.0D;
+		}
+	}
+
+	@Override
+	protected void slotChangedCraftingGrid(World world, EntityPlayer player, InventoryCrafting inv, InventoryCraftResult result) {
+	}
+
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ClientContainerFastWorkbench.java
@@ -1,51 +1,16 @@
 package com.lothrazar.cyclicmagic.compat.fastbench;
 
-import com.lothrazar.cyclicmagic.block.workbench.InventoryWorkbench;
 import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
-import com.lothrazar.cyclicmagic.core.util.Const;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryCraftResult;
 import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.inventory.Slot;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import shadows.fastbench.gui.ClientContainerFastBench;
-import shadows.fastbench.gui.SlotCraftingSucks;
 
-public class ClientContainerFastWorkbench extends ClientContainerFastBench {
-
-	static Block workbench = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Const.MODID, "block_workbench"));
-
-	final TileEntityWorkbench te;
+public class ClientContainerFastWorkbench extends ContainerFastWorkbench {
 
 	public ClientContainerFastWorkbench(EntityPlayer player, World world, TileEntityWorkbench te) {
-		super(player, world, te.getPos().getX(), te.getPos().getY(), te.getPos().getZ());
-		this.te = te;
-		this.craftMatrix = new InventoryWorkbench(this, te);
-		int x = 0;
-		replaceSlot(x++, new SlotCraftingSucks(this, player, this.craftMatrix, this.craftResult, 0, 124, 35));
-		for (int i = 0; i < 3; ++i) {
-			for (int j = 0; j < 3; ++j) {
-				replaceSlot(x++, new Slot(this.craftMatrix, j + i * 3, 30 + j * 18, 17 + i * 18));
-			}
-		}
-	}
-
-	void replaceSlot(int num, Slot slotIn) {
-		slotIn.slotNumber = num;
-		this.inventorySlots.set(num, slotIn);
-	}
-
-	@Override
-	public boolean canInteractWith(EntityPlayer playerIn) {
-		if (te.getWorld().getBlockState(te.getPos()).getBlock() != workbench) {
-			return false;
-		} else {
-			return playerIn.getDistanceSq(te.getPos().getX() + 0.5D, te.getPos().getY() + 0.5D, te.getPos().getZ() + 0.5D) <= 64.0D;
-		}
+		super(player, world, te);
 	}
 
 	@Override

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/CompatFastBench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/CompatFastBench.java
@@ -1,0 +1,9 @@
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import net.minecraftforge.fml.common.Loader;
+
+public class CompatFastBench {
+
+	public static final boolean LOADED = Loader.isModLoaded("fastbench");
+	
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ContainerFastPlayerBench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ContainerFastPlayerBench.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import javax.annotation.Nullable;
+
+import com.lothrazar.cyclicmagic.playerupgrade.crafting.InventoryPlayerExtWorkbench;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import shadows.fastbench.gui.ContainerFastBench;
+import shadows.fastbench.gui.SlotCraftingSucks;
+
+public class ContainerFastPlayerBench extends ContainerFastBench {
+
+	private static final EntityEquipmentSlot[] ARMOR = new EntityEquipmentSlot[] { EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET };
+	public static final int SLOT_SHIELD = 40;
+	public static final int SQ = 18;
+	public static final int VROW = 3;
+	public static final int VCOL = 9;
+	public static final int HOTBAR_SIZE = 9;
+	final int pad = 8;
+	EntityPlayer player;
+
+	public ContainerFastPlayerBench(EntityPlayer player, World world) {
+		super(player, world, BlockPos.ORIGIN);
+		this.player = player;
+		int xResult = 155, yResult = 22;
+		this.inventorySlots.clear();
+		this.inventoryItemStacks.clear();
+		int xPos, yPos;
+
+		this.addSlotToContainer(new SlotCraftingSucks(this, player, craftMatrix, craftResult, 0, xResult, yResult));
+
+		for (int i = 0; i < InventoryPlayerExtWorkbench.IROW; ++i) {
+			for (int j = 0; j < InventoryPlayerExtWorkbench.ICOL; ++j) {
+				xPos = (j + 1) * SQ + 65;
+				yPos = i * SQ + 6;
+				this.addSlotToContainer(new Slot(craftMatrix, j + i * 3, xPos, yPos));
+			}
+		}
+
+		for (int k = 0; k < 3; ++k) {
+			for (int i1 = 0; i1 < 9; ++i1) {
+				this.addSlotToContainer(new Slot(player.inventory, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
+			}
+		}
+
+		for (int l = 0; l < 9; ++l) {
+			this.addSlotToContainer(new Slot(player.inventory, l, 8 + l * 18, 142));
+		}
+
+		for (int k = 0; k < ARMOR.length; k++) {
+			final EntityEquipmentSlot slot = ARMOR[k];
+			this.addSlotToContainer(new Slot(player.inventory, 36 + (3 - k), pad, pad + k * SQ) {
+
+				@Override
+				public int getSlotStackLimit() {
+					return 1;
+				}
+
+				@Override
+				public boolean isItemValid(ItemStack stack) {
+					return !stack.isEmpty() && stack.getItem().isValidArmor(stack, slot, player);
+				}
+
+				@Override
+				public String getSlotTexture() {
+					return ItemArmor.EMPTY_SLOT_NAMES[slot.getIndex()];
+				}
+			});
+		}
+
+		this.addSlotToContainer(new Slot(player.inventory, 40, 77, 62) {
+
+			@Override
+			public boolean isItemValid(@Nullable ItemStack stack) {
+				return super.isItemValid(stack);
+			}
+
+			@Override
+			public String getSlotTexture() {
+				return "minecraft:items/empty_armor_slot_shield";
+			}
+		});
+	}
+
+	/**
+	 * Slot Index Map
+	 * Crafting Result: 0
+	 * Craft Matrix: 1-9
+	 * Main Inventory: 10-36
+	 * Hotbar: 37-45
+	 * Armor: 46-49
+	 * Offhand: 50
+	 */
+
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
+
+		if (slot != null && slot.getHasStack()) {
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+
+			if (index == 0) {
+				itemstack1.getItem().onCreated(itemstack1, playerIn.world, playerIn);
+				if (!this.mergeItemStack(itemstack1, 10, 46, true)) return ItemStack.EMPTY;
+				slot.onSlotChange(itemstack1, itemstack);
+
+			} else if (index >= 10 && index < 37) {
+				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 37, 46, false))) return ItemStack.EMPTY;
+
+			} else if (index >= 37 && index < 46) {
+				if (!(this.mergeItemStack(itemstack1, 46, 50, false) || this.mergeItemStack(itemstack1, 10, 37, false))) return ItemStack.EMPTY;
+
+			} else if (!this.mergeItemStack(itemstack1, 10, 46, false)) return ItemStack.EMPTY;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) return ItemStack.EMPTY;
+
+			ItemStack itemstack2 = slot.onTake(playerIn, itemstack1);
+
+			if (index == 0) {
+				playerIn.dropItem(itemstack2, false);
+			}
+		}
+
+		return itemstack;
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer playerIn) {
+		return true;
+	}
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ContainerFastWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/ContainerFastWorkbench.java
@@ -1,0 +1,50 @@
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import com.lothrazar.cyclicmagic.block.workbench.InventoryWorkbench;
+import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
+import com.lothrazar.cyclicmagic.core.util.Const;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Slot;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import shadows.fastbench.gui.ContainerFastBench;
+import shadows.fastbench.gui.SlotCraftingSucks;
+
+public class ContainerFastWorkbench extends ContainerFastBench {
+
+	static Block workbench = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Const.MODID, "block_workbench"));
+
+	final TileEntityWorkbench te;
+
+	public ContainerFastWorkbench(EntityPlayer player, World world, TileEntityWorkbench te) {
+		super(player, world, te.getPos());
+		this.te = te;
+		this.craftMatrix = new InventoryWorkbench(this, te);
+		int x = 0;
+		replaceSlot(x++, new SlotCraftingSucks(this, player, this.craftMatrix, this.craftResult, 0, 124, 35));
+		for (int i = 0; i < 3; ++i) {
+			for (int j = 0; j < 3; ++j) {
+				replaceSlot(x++, new Slot(this.craftMatrix, j + i * 3, 30 + j * 18, 17 + i * 18));
+			}
+		}
+		onCraftMatrixChanged(te);
+	}
+
+	void replaceSlot(int num, Slot slotIn) {
+		slotIn.slotNumber = num;
+		this.inventorySlots.set(num, slotIn);
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer playerIn) {
+		if (te.getWorld().getBlockState(te.getPos()).getBlock() != workbench) {
+			return false;
+		} else {
+			return playerIn.getDistanceSq(te.getPos().getX() + 0.5D, te.getPos().getY() + 0.5D, te.getPos().getZ() + 0.5D) <= 64.0D;
+		}
+	}
+
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/GuiFastPlayerBench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/GuiFastPlayerBench.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import java.util.Collection;
+
+import com.google.common.collect.Ordering;
+import com.lothrazar.cyclicmagic.core.util.Const;
+
+import net.minecraft.client.gui.GuiButton;
+//import net.minecraft.client.gui.achievement.GuiAchievements;
+import net.minecraft.client.gui.achievement.GuiStats;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import shadows.fastbench.gui.GuiFastBench;
+
+public class GuiFastPlayerBench extends GuiFastBench {
+
+	public static final ResourceLocation background = new ResourceLocation(Const.MODID, "textures/gui/inventorycraft.png");
+	protected boolean hasActivePotionEffects;
+	private float oldMouseX;
+	private float oldMouseY;
+
+	public GuiFastPlayerBench(EntityPlayer player) {
+		super(player.inventory, player.world, BlockPos.ORIGIN);
+		this.inventorySlots = new ClientContainerFastPlayerBench(player, player.world);
+		this.allowUserInput = true;
+	}
+
+	@Override
+	public void updateScreen() {
+		this.updateActivePotionEffects();
+	}
+
+	@Override
+	public void initGui() {
+		this.buttonList.clear();
+		super.initGui();
+		this.updateActivePotionEffects();
+	}
+
+	@Override
+	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+		super.drawScreen(mouseX, mouseY, partialTicks);
+		if (this.hasActivePotionEffects) {
+			this.drawActivePotionEffects();
+		}
+		this.renderHoveredToolTip(mouseX, mouseY);
+		this.oldMouseX = (float) mouseX;
+		this.oldMouseY = (float) mouseY;
+
+	}
+	
+	@Override
+	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+	}
+
+	@Override
+	protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		this.mc.getTextureManager().bindTexture(background);
+		int i = this.guiLeft;
+		int j = this.guiTop;
+		this.drawTexturedModalRect(i, j, 0, 0, this.xSize, this.ySize);
+		//COPIED FROM GuiInventory
+		GuiInventory.drawEntityOnScreen(i + 51, j + 75, 30, (float) (i + 51) - this.oldMouseX, (float) (j + 75 - 50) - this.oldMouseY, this.mc.player);
+	}
+
+	@Override
+	protected void actionPerformed(GuiButton button) {
+		//    if (button.id == 0) {
+		//      this.mc.displayGuiScreen(new GuiAchievements(this, this.mc.player.getStatFileWriter()));
+		//    }
+		if (button.id == 1) {
+			this.mc.displayGuiScreen(new GuiStats(this, this.mc.player.getStatFileWriter()));
+		}
+	}
+
+	protected void updateActivePotionEffects() {
+		boolean hasVisibleEffect = false;
+		for (PotionEffect potioneffect : this.mc.player.getActivePotionEffects()) {
+			Potion potion = potioneffect.getPotion();
+			if (potion.shouldRender(potioneffect)) {
+				hasVisibleEffect = true;
+				break;
+			}
+		}
+		if (this.mc.player.getActivePotionEffects().isEmpty() || !hasVisibleEffect) {
+			this.guiLeft = (this.width - this.xSize) / 2;
+			this.hasActivePotionEffects = false;
+		} else {
+			if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiScreenEvent.PotionShiftEvent(this))) this.guiLeft = (this.width - this.xSize) / 2;
+			else this.guiLeft = 160 + (this.width - this.xSize - 200) / 2;
+			this.hasActivePotionEffects = true;
+		}
+	}
+
+	private void drawActivePotionEffects() {
+		int i = this.guiLeft - 124;
+		int j = this.guiTop;
+		Collection<PotionEffect> collection = this.mc.player.getActivePotionEffects();
+
+		if (!collection.isEmpty()) {
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+			GlStateManager.disableLighting();
+			int l = 33;
+
+			if (collection.size() > 5) {
+				l = 132 / (collection.size() - 1);
+			}
+
+			for (PotionEffect potioneffect : Ordering.natural().sortedCopy(collection)) {
+				Potion potion = potioneffect.getPotion();
+				if (!potion.shouldRender(potioneffect)) continue;
+				GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+				this.mc.getTextureManager().bindTexture(INVENTORY_BACKGROUND);
+				this.drawTexturedModalRect(i, j, 0, 166, 140, 32);
+
+				if (potion.hasStatusIcon()) {
+					int i1 = potion.getStatusIconIndex();
+					this.drawTexturedModalRect(i + 6, j + 7, 0 + i1 % 8 * 18, 198 + i1 / 8 * 18, 18, 18);
+				}
+
+				potion.renderInventoryEffect(i, j, potioneffect, mc);
+				if (!potion.shouldRenderInvText(potioneffect)) {
+					j += l;
+					continue;
+				}
+				String s1 = I18n.format(potion.getName());
+
+				if (potioneffect.getAmplifier() == 1) {
+					s1 = s1 + " " + I18n.format("enchantment.level.2");
+				} else if (potioneffect.getAmplifier() == 2) {
+					s1 = s1 + " " + I18n.format("enchantment.level.3");
+				} else if (potioneffect.getAmplifier() == 3) {
+					s1 = s1 + " " + I18n.format("enchantment.level.4");
+				}
+
+				this.fontRenderer.drawStringWithShadow(s1, (float) (i + 10 + 18), (float) (j + 6), 16777215);
+				String s = Potion.getPotionDurationString(potioneffect, 1.0F);
+				this.fontRenderer.drawStringWithShadow(s, (float) (i + 10 + 18), (float) (j + 6 + 10), 8355711);
+				j += l;
+			}
+		}
+	}
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/GuiFastWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/fastbench/GuiFastWorkbench.java
@@ -1,0 +1,23 @@
+package com.lothrazar.cyclicmagic.compat.fastbench;
+
+import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.world.World;
+import shadows.fastbench.gui.GuiFastBench;
+
+public class GuiFastWorkbench extends GuiFastBench {
+
+	public GuiFastWorkbench(InventoryPlayer inv, World world, TileEntityWorkbench te) {
+		super(inv, world, te.getPos());
+		this.inventorySlots = new ClientContainerFastWorkbench(inv.player, world, te);
+	}
+
+	@Override
+	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+		this.fontRenderer.drawString(I18n.format("tile.block_workbench.name"), 28, 6, 4210752);
+		this.fontRenderer.drawString(I18n.format("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
+	}
+
+}

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/DehydratorRecipeCategory.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/DehydratorRecipeCategory.java
@@ -8,6 +8,7 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -18,8 +19,8 @@ public class DehydratorRecipeCategory implements IRecipeCategory<DehydratorWrapp
   private IDrawable icon;
 
   public DehydratorRecipeCategory(IGuiHelper helper) {
-    gui = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/gui/dehydrate_recipe.png"), 0, 0, 169, 69, 169, 69);
-    icon = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/blocks/dehydrator_bush.png"), 0, 0, 16, 16, 16, 16);
+    gui = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/gui/dehydrate_recipe.png"), 0, 0, 169, 69).setTextureSize(169, 69).build();
+    icon = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/blocks/dehydrator_bush.png"), 0, 0, 16, 16).setTextureSize(16, 16).build();
   }
 
   @Override
@@ -59,7 +60,7 @@ public class DehydratorRecipeCategory implements IRecipeCategory<DehydratorWrapp
     //    guiItemStacks.init(3, true, x, y);
     //    guiItemStacks.init(4, true, x + Const.SQ, y);
     //    guiItemStacks.init(5, true, x + 2 * Const.SQ, y);
-    List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
+    List<List<ItemStack>> inputs = ingredients.getInputs(VanillaTypes.ITEM);
     for (int i = 0; i < inputs.size(); i++) {
       List<ItemStack> input = inputs.get(i);
       if (input != null && input.isEmpty() == false)

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/DehydratorWrapper.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/DehydratorWrapper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import com.lothrazar.cyclicmagic.block.dehydrator.RecipeDeHydrate;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 
@@ -25,8 +26,8 @@ public class DehydratorWrapper implements IRecipeWrapper {
     //    for (ItemStack wtf : src.getInput()) {
     ing.add(src.getRecipeInput().copy());
     //    } 
-    ingredients.setInputs(ItemStack.class, ing);
-    ingredients.setOutput(ItemStack.class, src.getRecipeOutput());
+    ingredients.setInputs(VanillaTypes.ITEM, ing);
+    ingredients.setOutput(VanillaTypes.ITEM, src.getRecipeOutput());
   }
   //  public int size() {
   //    int size = 0;

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/HydratorRecipeCategory.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/HydratorRecipeCategory.java
@@ -8,6 +8,7 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -18,8 +19,8 @@ public class HydratorRecipeCategory implements IRecipeCategory<HydratorWrapper> 
   private IDrawable icon;
 
   public HydratorRecipeCategory(IGuiHelper helper) {
-    gui = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/gui/hydrator_recipe.png"), 0, 0, 169, 69, 169, 69);
-    icon = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/blocks/hydrator.png"), 0, 0, 16, 16, 16, 16);
+    gui = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/gui/hydrator_recipe.png"), 0, 0, 169, 69).setTextureSize(169, 69).build();
+    icon = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/blocks/hydrator.png"), 0, 0, 16, 16).setTextureSize(16, 16).build();
   }
 
   @Override
@@ -54,7 +55,7 @@ public class HydratorRecipeCategory implements IRecipeCategory<HydratorWrapper> 
     guiItemStacks.init(1, true, 3, 2 * Const.SQ);
     guiItemStacks.init(2, true, 3 + Const.SQ, Const.SQ);
     guiItemStacks.init(3, true, 3 + Const.SQ, 2 * Const.SQ);
-    List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
+    List<List<ItemStack>> inputs = ingredients.getInputs(VanillaTypes.ITEM);
     for (int i = 0; i < inputs.size(); i++) {
       List<ItemStack> input = inputs.get(i);
       if (input != null && input.isEmpty() == false)

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/HydratorWrapper.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/HydratorWrapper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import com.lothrazar.cyclicmagic.block.hydrator.RecipeHydrate;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 
@@ -25,8 +26,8 @@ public class HydratorWrapper implements IRecipeWrapper {
     for (ItemStack wtf : src.getRecipeInput()) {
       ing.add(wtf.copy());
     }
-    ingredients.setInputs(ItemStack.class, ing);
-    ingredients.setOutput(ItemStack.class, src.getRecipeOutput());
+    ingredients.setInputs(VanillaTypes.ITEM, ing);
+    ingredients.setOutput(VanillaTypes.ITEM, src.getRecipeOutput());
   }
   //  public int size() {
   //    int size = 0;

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/JEIPlugin.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/JEIPlugin.java
@@ -38,6 +38,7 @@ import com.lothrazar.cyclicmagic.playerupgrade.crafting.ContainerPlayerExtWorkbe
 import com.lothrazar.cyclicmagic.registry.ItemRegistry;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import net.minecraft.block.Block;
@@ -51,7 +52,6 @@ public class JEIPlugin implements IModPlugin { // extends mezz.jei.api.BlankModP
   static final String RECIPE_CATEGORY_DEHYDRATOR = "dehydrator";
   static final String RECIPE_CATEGORY_PACKAGER = "packager";
 
-  @SuppressWarnings("deprecation")
   @Override
   public void register(IModRegistry registry) {
     ////////////////first register all crafting GUI's
@@ -92,24 +92,21 @@ public class JEIPlugin implements IModPlugin { // extends mezz.jei.api.BlankModP
     registry.addRecipeClickArea(GuiHydrator.class, 75, 0, 40, 26, RECIPE_CATEGORY_HYDRATOR);
     registry.handleRecipes(RecipeHydrate.class, new HydratorFactory(), RECIPE_CATEGORY_HYDRATOR);
     registry.addRecipes(RecipeHydrate.recipes, RECIPE_CATEGORY_HYDRATOR);
-    registry.addRecipeCategoryCraftingItem(new ItemStack(Block.getBlockFromName("cyclicmagic:block_hydrator")), RECIPE_CATEGORY_HYDRATOR);
+    registry.addRecipeCatalyst(new ItemStack(Block.getBlockFromName("cyclicmagic:block_hydrator")), RECIPE_CATEGORY_HYDRATOR);
     // End Custom recipe type: Hydrator
     // Packager
     registry.addRecipeClickArea(GuiPackager.class, 75, 0, 40, 26, RECIPE_CATEGORY_PACKAGER);
     registry.handleRecipes(RecipePackage.class, new PackagerFactory(), RECIPE_CATEGORY_PACKAGER);
     registry.addRecipes(RecipePackage.recipes, RECIPE_CATEGORY_PACKAGER);
-    registry.addRecipeCategoryCraftingItem(new ItemStack(Block.getBlockFromName("cyclicmagic:auto_packager")), RECIPE_CATEGORY_PACKAGER);
+    registry.addRecipeCatalyst(new ItemStack(Block.getBlockFromName("cyclicmagic:auto_packager")), RECIPE_CATEGORY_PACKAGER);
     //DEHydrator
     registry.addRecipeClickArea(GuiDeHydrator.class, 75, 0, 40, 26, RECIPE_CATEGORY_DEHYDRATOR);
     registry.handleRecipes(RecipeDeHydrate.class, new DehydratorFactory(), RECIPE_CATEGORY_DEHYDRATOR);
     registry.addRecipes(RecipeDeHydrate.recipes, RECIPE_CATEGORY_DEHYDRATOR);
-    registry.addRecipeCategoryCraftingItem(new ItemStack(Block.getBlockFromName("cyclicmagic:dehydrator")), RECIPE_CATEGORY_DEHYDRATOR);
+    registry.addRecipeCatalyst(new ItemStack(Block.getBlockFromName("cyclicmagic:dehydrator")), RECIPE_CATEGORY_DEHYDRATOR);
     //Start of the Info tab
     for (Item item : ItemRegistry.itemList) {
-      //YES its deprecated. but new method is NOT in wiki. at all. 
-      // i found something similar... and didnt work when i tried
-      //https://github.com/mezz/JustEnoughItems/wiki/Recipes-Overview
-      registry.addDescription(new ItemStack(item), item.getUnlocalizedName() + ".guide");
+      registry.addIngredientInfo(new ItemStack(item), VanillaTypes.ITEM, item.getTranslationKey() + ".guide");
     }
     //end of Info tab
   }

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/PackagerRecipeCategory.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/PackagerRecipeCategory.java
@@ -8,6 +8,7 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -18,8 +19,8 @@ public class PackagerRecipeCategory implements IRecipeCategory<PackagerWrapper> 
   private IDrawable icon;
 
   public PackagerRecipeCategory(IGuiHelper helper) {
-    gui = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/gui/packager_recipe.png"), 0, 0, 169, 69, 169, 69);
-    icon = helper.createDrawable(new ResourceLocation(Const.MODID, "textures/blocks/auto_packager.png"), 0, 0, 16, 16, 16, 16);
+    gui = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/gui/packager_recipe.png"), 0, 0, 169, 69).setTextureSize(169, 69).build();
+    icon = helper.drawableBuilder(new ResourceLocation(Const.MODID, "textures/blocks/auto_packager.png"), 0, 0, 16, 16).setTextureSize(16, 16).build();
   }
 
   @Override
@@ -59,7 +60,7 @@ public class PackagerRecipeCategory implements IRecipeCategory<PackagerWrapper> 
     guiItemStacks.init(3, true, x, y);
     guiItemStacks.init(4, true, x + Const.SQ, y);
     guiItemStacks.init(5, true, x + 2 * Const.SQ, y);
-    List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
+    List<List<ItemStack>> inputs = ingredients.getInputs(VanillaTypes.ITEM);
     for (int i = 0; i < inputs.size(); i++) {
       List<ItemStack> input = inputs.get(i);
       if (input != null && input.isEmpty() == false)

--- a/src/main/java/com/lothrazar/cyclicmagic/compat/jei/PackagerWrapper.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/compat/jei/PackagerWrapper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import com.lothrazar.cyclicmagic.block.packager.RecipePackage;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 
@@ -25,8 +26,8 @@ public class PackagerWrapper implements IRecipeWrapper {
     for (ItemStack wtf : src.getInput()) {
       ing.add(wtf.copy());
     }
-    ingredients.setInputs(ItemStack.class, ing);
-    ingredients.setOutput(ItemStack.class, src.getRecipeOutput());
+    ingredients.setInputs(VanillaTypes.ITEM, ing);
+    ingredients.setOutput(VanillaTypes.ITEM, src.getRecipeOutput());
   }
   //
   //  public int size() {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BaseTESR.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BaseTESR.java
@@ -53,7 +53,7 @@ public abstract class BaseTESR<T extends TileEntity> extends TileEntitySpecialRe
 
   public BaseTESR(@Nullable Block block) {
     if (block != null)
-      resource = "tesr/" + block.getUnlocalizedName().replace("tile.", "").replace(".name", "");
+      resource = "tesr/" + block.getTranslationKey().replace("tile.", "").replace(".name", "");
   }
 
   @Nullable

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBase.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBase.java
@@ -57,7 +57,7 @@ public abstract class BlockBase extends Block {
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
     if (myTooltip == null) {
-      myTooltip = this.getUnlocalizedName() + ".tooltip";
+      myTooltip = this.getTranslationKey() + ".tooltip";
     }
     tooltip.add(UtilChat.lang(myTooltip));
   }
@@ -69,10 +69,10 @@ public abstract class BlockBase extends Block {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     if (this.isTransp)
       return BlockRenderLayer.TRANSLUCENT;
     else
-      return super.getBlockLayer(); // SOLID
+      return super.getRenderLayer(); // SOLID
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFacing.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFacing.java
@@ -44,7 +44,7 @@ public abstract class BlockBaseFacing extends BlockBaseHasTile {
 
   @Override
   public IBlockState getStateFromMeta(int meta) {
-    EnumFacing facing = EnumFacing.getHorizontal(meta);
+    EnumFacing facing = EnumFacing.byHorizontalIndex(meta);
     return this.getDefaultState().withProperty(PROPERTYFACING, facing);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFacingOmni.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFacingOmni.java
@@ -57,7 +57,7 @@ public abstract class BlockBaseFacingOmni extends BlockBaseHasTile {
 
   @Override
   public IBlockState getStateFromMeta(int meta) {
-    return this.getDefaultState().withProperty(PROPERTYFACING, EnumFacing.getFront(meta & 7));
+    return this.getDefaultState().withProperty(PROPERTYFACING, EnumFacing.byIndex(meta & 7));
   }
 
   public EnumFacing getFacingFromState(IBlockState state) {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFlat.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseFlat.java
@@ -63,7 +63,7 @@ public abstract class BlockBaseFlat extends BlockBase {
 
   @SideOnly(Side.CLIENT)
   @Override
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer() {
     return BlockRenderLayer.TRANSLUCENT;
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseHasTile.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/BlockBaseHasTile.java
@@ -89,6 +89,6 @@ public abstract class BlockBaseHasTile extends BlockBase {
   }
 
   public String getRawName() {
-    return this.getUnlocalizedName().replace("tile.", "");
+    return this.getTranslationKey().replace("tile.", "");
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/core/block/TileEntityBaseMachineInvo.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/block/TileEntityBaseMachineInvo.java
@@ -290,7 +290,7 @@ public abstract class TileEntityBaseMachineInvo extends TileEntityBaseMachine im
       ModCyclic.logger.error(" null blockType:" + this.getClass().getName());
       return "";
     }
-    return this.getBlockType().getUnlocalizedName() + ".name";
+    return this.getBlockType().getTranslationKey() + ".name";
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItem.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItem.java
@@ -36,7 +36,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public abstract class BaseItem extends Item {
 
   protected String getTooltip() {
-    return this.getUnlocalizedName() + ".tooltip";
+    return this.getTranslationKey() + ".tooltip";
   }
 
   @SideOnly(Side.CLIENT)

--- a/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemChargeScepter.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemChargeScepter.java
@@ -239,7 +239,7 @@ public abstract class BaseItemChargeScepter extends BaseTool {
   protected void launchProjectile(World world, EntityPlayer player, EntityThrowable thing, float velocity) {
     if (!world.isRemote) {
       //zero pitch offset, meaning match the players existing. 1.0 at end ins inn
-      thing.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
+      thing.shoot(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
       world.spawnEntity(thing);
     }
     BlockPos pos = player.getPosition();

--- a/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemMinecart.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemMinecart.java
@@ -90,9 +90,9 @@ public abstract class BaseItemMinecart extends BaseItem {
       }
       EnumFacing enumfacing = (EnumFacing) source.getBlockState().getValue(BlockDispenser.FACING);
       World world = source.getWorld();
-      double d0 = source.getX() + (double) enumfacing.getFrontOffsetX() * 1.125D;
-      double d1 = Math.floor(source.getY()) + (double) enumfacing.getFrontOffsetY();
-      double d2 = source.getZ() + (double) enumfacing.getFrontOffsetZ() * 1.125D;
+      double d0 = source.getX() + (double) enumfacing.getXOffset() * 1.125D;
+      double d1 = Math.floor(source.getY()) + (double) enumfacing.getYOffset();
+      double d2 = source.getZ() + (double) enumfacing.getZOffset() * 1.125D;
       BlockPos blockpos = source.getBlockPos().offset(enumfacing);
       IBlockState iblockstate = world.getBlockState(blockpos);
       BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = iblockstate.getBlock() instanceof BlockRailBase ? ((BlockRailBase) iblockstate.getBlock()).getRailDirection(world, blockpos, iblockstate, null) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;

--- a/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemProjectile.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemProjectile.java
@@ -60,7 +60,7 @@ public abstract class BaseItemProjectile extends BaseItem {
     if (!world.isRemote) {
       // func_184538_a
       //zero pitch offset, meaning match the players existing. 1.0 at end ins inn
-      thing.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
+      thing.shoot(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
       world.spawnEntity(thing);
     }
     player.swingArm(hand);

--- a/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemRapidScepter.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/item/BaseItemRapidScepter.java
@@ -107,7 +107,7 @@ public abstract class BaseItemRapidScepter extends BaseTool {
   protected void launchProjectile(World world, EntityPlayer player, EntityThrowable thing, float velocity) {
     if (!world.isRemote) {
       //zero pitch offset, meaning match the players existing. 1.0 at end ins inn
-      thing.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
+      thing.shoot(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, velocity, INACCURACY_DEFAULT);
       world.spawnEntity(thing);
     }
     BlockPos pos = player.getPosition();

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilEntity.java
@@ -87,7 +87,7 @@ public class UtilEntity {
   public static void teleportWallSafe(EntityLivingBase player, World world, double x, double y, double z) {
     BlockPos coords = new BlockPos(x, y, z);
     world.markBlockRangeForRenderUpdate(coords, coords);
-    world.getChunkFromBlockCoords(coords).setModified(true);
+    world.getChunk(coords).setModified(true);
     player.setPositionAndUpdate(x, y, z);
     moveEntityWallSafe(player, world);
   }
@@ -139,7 +139,7 @@ public class UtilEntity {
     yaw %= 360; // and this one if you want a strict interpretation of the
     // zones
     int facing = yaw / 45; // 360degrees divided by 45 == 8 zones
-    return EnumFacing.getHorizontal(facing / 2);
+    return EnumFacing.byHorizontalIndex(facing / 2);
   }
 
   public static double getSpeedTranslated(double speed) {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilGenerateRecipeJson.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilGenerateRecipeJson.java
@@ -87,10 +87,10 @@ public class UtilGenerateRecipeJson {
     // repeatedly adds _alt if a file already exists
     // janky I know but it works
     String suffix = result.getItem().getHasSubtypes() ? "_" + result.getItemDamage() : "";
-    File f = new File(RECIPE_DIR, result.getItem().getRegistryName().getResourcePath() + suffix + ".json");
+    File f = new File(RECIPE_DIR, result.getItem().getRegistryName().getPath() + suffix + ".json");
     while (f.exists()) {
       suffix += "_alt";
-      f = new File(RECIPE_DIR, result.getItem().getRegistryName().getResourcePath() + suffix + ".json");
+      f = new File(RECIPE_DIR, result.getItem().getRegistryName().getPath() + suffix + ".json");
     }
     try (FileWriter w = new FileWriter(f)) {
       GSON.toJson(json, w);
@@ -120,10 +120,10 @@ public class UtilGenerateRecipeJson {
     // repeatedly adds _alt if a file already exists
     // janky I know but it works
     String suffix = result.getItem().getHasSubtypes() ? "_" + result.getItemDamage() : "";
-    File f = new File(RECIPE_DIR, result.getItem().getRegistryName().getResourcePath() + suffix + ".json");
+    File f = new File(RECIPE_DIR, result.getItem().getRegistryName().getPath() + suffix + ".json");
     while (f.exists()) {
       suffix += "_alt";
-      f = new File(RECIPE_DIR, result.getItem().getRegistryName().getResourcePath() + suffix + ".json");
+      f = new File(RECIPE_DIR, result.getItem().getRegistryName().getPath() + suffix + ".json");
     }
     try (FileWriter w = new FileWriter(f)) {
       GSON.toJson(json, w);

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilItemStack.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilItemStack.java
@@ -192,18 +192,18 @@ public class UtilItemStack {
 
   public static @Nonnull String getStringForItemStack(ItemStack itemStack) {
     Item item = itemStack.getItem();
-    return item.getRegistryName().getResourceDomain() + ":" + item.getRegistryName().getResourcePath() + "/" + itemStack.getMetadata();
+    return item.getRegistryName().getNamespace() + ":" + item.getRegistryName().getPath() + "/" + itemStack.getMetadata();
   }
 
   public static String getStringForItem(Item item) {
     if (item == null || item.getRegistryName() == null) {
       return "";
     }
-    return item.getRegistryName().getResourceDomain() + ":" + item.getRegistryName().getResourcePath();
+    return item.getRegistryName().getNamespace() + ":" + item.getRegistryName().getPath();
   }
 
   public static String getStringForBlock(Block b) {
-    return b.getRegistryName().getResourceDomain() + ":" + b.getRegistryName().getResourcePath();
+    return b.getRegistryName().getNamespace() + ":" + b.getRegistryName().getPath();
   }
 
   public static void dropBlockState(World world, BlockPos position, IBlockState current) {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilPlayerInventoryFilestorage.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilPlayerInventoryFilestorage.java
@@ -115,7 +115,7 @@ public class UtilPlayerInventoryFilestorage {
             e.printStackTrace();
           }
         }
-        if (file1 == null || !file1.exists() || data == null || data.hasNoTags()) {
+        if (file1 == null || !file1.exists() || data == null || data.isEmpty()) {
           ModCyclic.logger.error("Data not found for " + player.getDisplayNameString());//+ ". Trying to load backup data."
           //          if (file2 != null && file2.exists()) {
           //            try {

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilScythe.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilScythe.java
@@ -268,7 +268,7 @@ public class UtilScythe {
       }
       return true;
     }
-    if (blockCheck.getRegistryName().getResourceDomain().equals("minecraft") == false) {
+    if (blockCheck.getRegistryName().getNamespace().equals("minecraft") == false) {
       ModCyclic.logger.log("SCYTHE could not clip " + blockId);
     }
     return false;

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilString.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilString.java
@@ -46,7 +46,7 @@ public class UtilString {
     if (toMatch == null) {
       return false;
     }
-    String id = toMatch.getResourceDomain().toString();
+    String id = toMatch.getNamespace();
     for (String strFromList : list) {
       if (strFromList.equals(id)) {
         return true;
@@ -54,8 +54,8 @@ public class UtilString {
       if (matchWildcard) {
         String modIdFromList = strFromList.split(":")[0];
         String blockIdFromList = strFromList.split(":")[1];//has the *
-        String modIdToMatch = toMatch.getResourceDomain();
-        String blockIdToMatch = toMatch.getResourcePath();
+        String modIdToMatch = toMatch.getNamespace();
+        String blockIdToMatch = toMatch.getPath();
         if (modIdFromList.equals(modIdToMatch) == false) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilTextureRender.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilTextureRender.java
@@ -44,13 +44,13 @@ public class UtilTextureRender {
       Gui.drawModalRectWithCustomSizedTexture(x, y, 0F, 0F, w, h, w, h);
     }
     catch (NullPointerException e) {
-      ModCyclic.logger.error("Null pointer drawTexture;Simple " + res.getResourcePath());
+      ModCyclic.logger.error("Null pointer drawTexture;Simple " + res.getPath());
       ModCyclic.logger.error(e.getMessage());
       e.printStackTrace();
     }
     catch (net.minecraft.util.ReportedException e) {
       ModCyclic.logger.error("net.minecraft.util.ReportedException ");
-      ModCyclic.logger.error(res.getResourceDomain() + ":" + res.getResourcePath());
+      ModCyclic.logger.error(res.getNamespace() + ":" + res.getPath());
       ModCyclic.logger.error(e.getMessage());
       e.printStackTrace();
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilUncraft.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilUncraft.java
@@ -97,7 +97,7 @@ public class UtilUncraft {
           }
         }
       case MODNAME:
-        String modId = item.getRegistryName().getResourceDomain();// the minecraft part of minecraft:wool (without colon)
+        String modId = item.getRegistryName().getNamespace();// the minecraft part of minecraft:wool (without colon)
         for (String s : blacklistMod) {//dont use .contains on the list. must use .equals on string
           if (s != null && s.equals(modId)) {
             return true;

--- a/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilWorld.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/core/util/UtilWorld.java
@@ -261,7 +261,7 @@ public class UtilWorld {
     if (pos == null) {
       return false;
     }
-    return world.isAirBlock(pos) || world.getBlockState(pos).getBlock().getUnlocalizedName().equalsIgnoreCase("tile.water") || (world.getBlockState(pos) != null
+    return world.isAirBlock(pos) || world.getBlockState(pos).getBlock().getTranslationKey().equalsIgnoreCase("tile.water") || (world.getBlockState(pos) != null
         && waterBoth.contains(world.getBlockState(pos).getBlock()));
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/creativetab/CreativeTabCyclic.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/creativetab/CreativeTabCyclic.java
@@ -58,7 +58,7 @@ public class CreativeTabCyclic extends CreativeTabs {
   }
 
   @Override
-  public ItemStack getTabIconItem() {
+  public ItemStack createIcon() {
     return tabItem == null ? new ItemStack(Items.DIAMOND) : new ItemStack(tabItem);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantMultishot.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantMultishot.java
@@ -88,7 +88,7 @@ public class EnchantMultishot extends EnchantBase {
     entityarrow.posX += offsetVector.x;
     entityarrow.posY += offsetVector.y;
     entityarrow.posZ += offsetVector.z;
-    entityarrow.setAim(player, player.rotationPitch, player.rotationYaw, 0.0F, charge * 3.0F, 1.0F);
+    entityarrow.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, charge * 3.0F, 1.0F);
     //from ItemBow vanilla class
     if (charge == 1.0F) {
       entityarrow.setIsCritical(true);

--- a/src/main/java/com/lothrazar/cyclicmagic/gui/ForgeGuiHandler.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/gui/ForgeGuiHandler.java
@@ -147,7 +147,9 @@ import com.lothrazar.cyclicmagic.block.workbench.ContainerWorkBench;
 import com.lothrazar.cyclicmagic.block.workbench.GuiWorkbench;
 import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
 import com.lothrazar.cyclicmagic.compat.fastbench.CompatFastBench;
+import com.lothrazar.cyclicmagic.compat.fastbench.ContainerFastPlayerBench;
 import com.lothrazar.cyclicmagic.compat.fastbench.ContainerFastWorkbench;
+import com.lothrazar.cyclicmagic.compat.fastbench.GuiFastPlayerBench;
 import com.lothrazar.cyclicmagic.compat.fastbench.GuiFastWorkbench;
 import com.lothrazar.cyclicmagic.core.util.UtilEntity;
 import com.lothrazar.cyclicmagic.core.util.UtilPlayer;
@@ -244,7 +246,7 @@ public class ForgeGuiHandler implements IGuiHandler {
       case GUI_INDEX_EXTENDED:
         return new ContainerPlayerExtended(player.inventory, new InventoryPlayerExtended(player), player);
       case GUI_INDEX_PWORKBENCH:
-        return new ContainerPlayerExtWorkbench(player.inventory, player);
+        return CompatFastBench.LOADED ? new ContainerFastPlayerBench(player, world) : new ContainerPlayerExtWorkbench(player.inventory, player);
       case GUI_INDEX_WAND:
         ItemStack wand = UtilSpellCaster.getPlayerWandIfHeld(player);
         return new ContainerWand(player, player.inventory, new InventoryWand(player, wand));
@@ -487,7 +489,7 @@ public class ForgeGuiHandler implements IGuiHandler {
         case GUI_INDEX_EXTENDED:
           return new GuiPlayerExtended(new ContainerPlayerExtended(player.inventory, new InventoryPlayerExtended(player), player));
         case GUI_INDEX_PWORKBENCH:
-          return new GuiPlayerExtWorkbench(new ContainerPlayerExtWorkbench(player.inventory, player));
+          return CompatFastBench.LOADED ? new GuiFastPlayerBench(player) : new GuiPlayerExtWorkbench(new ContainerPlayerExtWorkbench(player.inventory, player));
         case GUI_INDEX_WAND:
           ItemStack wand = UtilSpellCaster.getPlayerWandIfHeld(player);
           return new GuiWandInventory(new ContainerWand(player, player.inventory, new InventoryWand(player, wand)), wand);

--- a/src/main/java/com/lothrazar/cyclicmagic/gui/ForgeGuiHandler.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/gui/ForgeGuiHandler.java
@@ -146,6 +146,9 @@ import com.lothrazar.cyclicmagic.block.vector.TileEntityVector;
 import com.lothrazar.cyclicmagic.block.workbench.ContainerWorkBench;
 import com.lothrazar.cyclicmagic.block.workbench.GuiWorkbench;
 import com.lothrazar.cyclicmagic.block.workbench.TileEntityWorkbench;
+import com.lothrazar.cyclicmagic.compat.fastbench.CompatFastBench;
+import com.lothrazar.cyclicmagic.compat.fastbench.ContainerFastWorkbench;
+import com.lothrazar.cyclicmagic.compat.fastbench.GuiFastWorkbench;
 import com.lothrazar.cyclicmagic.core.util.UtilEntity;
 import com.lothrazar.cyclicmagic.core.util.UtilPlayer;
 import com.lothrazar.cyclicmagic.core.util.UtilSpellCaster;
@@ -166,6 +169,7 @@ import com.lothrazar.cyclicmagic.playerupgrade.crafting.GuiPlayerExtWorkbench;
 import com.lothrazar.cyclicmagic.playerupgrade.storage.ContainerPlayerExtended;
 import com.lothrazar.cyclicmagic.playerupgrade.storage.GuiPlayerExtended;
 import com.lothrazar.cyclicmagic.playerupgrade.storage.InventoryPlayerExtended;
+
 import net.minecraft.client.gui.inventory.GuiEditSign;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.passive.EntityVillager;
@@ -345,7 +349,7 @@ public class ForgeGuiHandler implements IGuiHandler {
       break;
       case GUI_INDEX_WORKBENCH:
         if (te instanceof TileEntityWorkbench) {
-          return new ContainerWorkBench(player.inventory, (TileEntityWorkbench) te);
+          return CompatFastBench.LOADED ? new ContainerFastWorkbench(player, world, (TileEntityWorkbench) te) : new ContainerWorkBench(player.inventory, (TileEntityWorkbench) te);
         }
       break;
       case GUI_INDEX_HYDRATOR:
@@ -579,7 +583,7 @@ public class ForgeGuiHandler implements IGuiHandler {
         break;
         case GUI_INDEX_WORKBENCH:
           if (te instanceof TileEntityWorkbench) {
-            return new GuiWorkbench(player.inventory, (TileEntityWorkbench) te);
+            return CompatFastBench.LOADED ? new GuiFastWorkbench(player.inventory, world, (TileEntityWorkbench) te) : new GuiWorkbench(player.inventory, (TileEntityWorkbench) te);
           }
         break;
         case GUI_INDEX_HYDRATOR:

--- a/src/main/java/com/lothrazar/cyclicmagic/guide/GuideRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/guide/GuideRegistry.java
@@ -51,8 +51,8 @@ public class GuideRegistry {
   }
 
   public static GuideItem register(GuideCategory cat, Block block, @Nullable IRecipe recipe, @Nullable List<String> args) {
-    String pageTitle = block.getUnlocalizedName() + ".name";
-    String text = block.getUnlocalizedName() + SUFFIX;
+    String pageTitle = block.getTranslationKey() + ".name";
+    String text = block.getTranslationKey() + SUFFIX;
     return register(cat, Item.getItemFromBlock(block), pageTitle, text, recipe, args);
   }
 
@@ -61,8 +61,8 @@ public class GuideRegistry {
   }
 
   public static GuideItem register(GuideCategory cat, Item item, @Nullable IRecipe recipe, @Nullable List<String> args) {
-    String pageTitle = item.getUnlocalizedName() + ".name";
-    String above = item.getUnlocalizedName() + SUFFIX;
+    String pageTitle = item.getTranslationKey() + ".name";
+    String above = item.getTranslationKey() + SUFFIX;
     return register(cat, item, pageTitle, above, recipe, args);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/item/ItemLeverRemote.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/ItemLeverRemote.java
@@ -78,7 +78,7 @@ public class ItemLeverRemote extends BaseItem implements IHasRecipe {
       //and save dimension
       UtilNBT.setItemStackNBTVal(stack, "LeverDim", playerIn.dimension);
       if (worldIn.isRemote) {
-        UtilChat.sendStatusMessage(playerIn, this.getUnlocalizedName() + ".saved");
+        UtilChat.sendStatusMessage(playerIn, this.getTranslationKey() + ".saved");
       }
       UtilSound.playSound(playerIn, SoundEvents.BLOCK_LEVER_CLICK);
       return EnumActionResult.SUCCESS;
@@ -114,7 +114,7 @@ public class ItemLeverRemote extends BaseItem implements IHasRecipe {
     //default is zero which is ok
     if (blockPos == null) {
       if (world.isRemote) {
-        UtilChat.sendStatusMessage(player, this.getUnlocalizedName() + ".invalid");
+        UtilChat.sendStatusMessage(player, this.getTranslationKey() + ".invalid");
       }
       return false;
     }
@@ -124,14 +124,14 @@ public class ItemLeverRemote extends BaseItem implements IHasRecipe {
       IBlockState blockState = world.getBlockState(blockPos);
       if (blockState == null || blockState.getBlock() != Blocks.LEVER) {
         if (world.isRemote) {
-          UtilChat.sendStatusMessage(player, this.getUnlocalizedName() + ".invalid");
+          UtilChat.sendStatusMessage(player, this.getTranslationKey() + ".invalid");
         }
         return false;
       }
       blockState = world.getBlockState(blockPos);
       boolean hasPowerHere = blockState.getValue(BlockLever.POWERED);
       UtilWorld.toggleLeverPowerState(world, blockPos, blockState);
-      UtilChat.sendStatusMessage(player, this.getUnlocalizedName() + ".powered." + hasPowerHere);
+      UtilChat.sendStatusMessage(player, this.getTranslationKey() + ".powered." + hasPowerHere);
       UtilSound.playSound(player, SoundEvents.BLOCK_LEVER_CLICK);
       player.getCooldownTracker().setCooldown(this, 20);
       return true;
@@ -156,7 +156,7 @@ public class ItemLeverRemote extends BaseItem implements IHasRecipe {
         IBlockState blockState = dw.getBlockState(blockPos);
         boolean hasPowerHere = blockState.getValue(BlockLever.POWERED);//this.block.getStrongPower(blockState, worldIn, pointer, EnumFacing.UP) > 0;
         UtilWorld.toggleLeverPowerState(dw, blockPos, blockState);
-        ModCyclic.network.sendTo(new PacketChat(this.getUnlocalizedName() + ".powered." + hasPowerHere, true), mp);
+        ModCyclic.network.sendTo(new PacketChat(this.getTranslationKey() + ".powered." + hasPowerHere, true), mp);
         UtilSound.playSound(player, SoundEvents.BLOCK_LEVER_CLICK);
         player.getCooldownTracker().setCooldown(this, 20);
         return true;

--- a/src/main/java/com/lothrazar/cyclicmagic/item/ItemMattock.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/ItemMattock.java
@@ -87,8 +87,8 @@ public class ItemMattock extends ItemTool implements IHasRecipe {
   }
 
   @Override
-  public float getStrVsBlock(ItemStack stack, IBlockState state) {
-    return state.getMaterial() != Material.IRON && state.getMaterial() != Material.ANVIL && state.getMaterial() != Material.ROCK ? super.getStrVsBlock(stack, state) : this.efficiencyOnProperMaterial;
+  public float getDestroySpeed(ItemStack stack, IBlockState state) {
+    return state.getMaterial() != Material.IRON && state.getMaterial() != Material.ANVIL && state.getMaterial() != Material.ROCK ? super.getDestroySpeed(stack, state) : this.efficiency;
   }
 
   /**
@@ -142,7 +142,7 @@ public class ItemMattock extends ItemTool implements IHasRecipe {
       if (world.isRemote) {//C
         world.playEvent(2001, posCurrent, Block.getStateId(bsCurrent));
         if (blockCurrent.removedByPlayer(bsCurrent, world, posCurrent, player, true)) {
-          blockCurrent.onBlockDestroyedByPlayer(world, posCurrent, bsCurrent);
+          blockCurrent.onPlayerDestroy(world, posCurrent, bsCurrent);
         }
         stack.onBlockDestroyed(world, bsCurrent, posCurrent, player);//update tool damage
         if (stack.getCount() == 0 && stack == player.getHeldItemMainhand()) {
@@ -157,7 +157,7 @@ public class ItemMattock extends ItemTool implements IHasRecipe {
         if (xpGivenOnDrop >= 0) {
           if (blockCurrent.removedByPlayer(bsCurrent, world, posCurrent, player, true)) {
             TileEntity tile = world.getTileEntity(posCurrent);
-            blockCurrent.onBlockDestroyedByPlayer(world, posCurrent, bsCurrent);
+            blockCurrent.onPlayerDestroy(world, posCurrent, bsCurrent);
             blockCurrent.harvestBlock(world, player, posCurrent, bsCurrent, tile, stack);
             blockCurrent.dropXpOnBlockBreak(world, posCurrent, xpGivenOnDrop);
           }
@@ -171,7 +171,7 @@ public class ItemMattock extends ItemTool implements IHasRecipe {
   @SideOnly(Side.CLIENT)
   @Override
   public void addInformation(ItemStack held, World player, List<String> list, net.minecraft.client.util.ITooltipFlag par4) {
-    list.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    list.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
     super.addInformation(held, player, list, par4);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/item/ItemObsShears.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/ItemObsShears.java
@@ -38,11 +38,11 @@ public class ItemObsShears extends ItemShears implements IHasRecipe {
   }
 
   @Override
-  public float getStrVsBlock(ItemStack stack, IBlockState state) {
+  public float getDestroySpeed(ItemStack stack, IBlockState state) {
     Block block = state.getBlock();
     if (block == Blocks.MELON_BLOCK || block == Blocks.PUMPKIN) {
       return 15F;//
     }
-    return super.getStrVsBlock(stack, state);
+    return super.getDestroySpeed(stack, state);
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/ItemSpawnInspect.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/ItemSpawnInspect.java
@@ -72,7 +72,7 @@ public class ItemSpawnInspect extends BaseTool implements IHasRecipe {
     if (!worldObj.isRemote) {
       ChunkProviderServer s = (ChunkProviderServer) worldObj.getChunkProvider();
       BlockPos pos = posIn.offset(side);
-      Chunk chunk = worldObj.getChunkFromBlockCoords(pos);
+      Chunk chunk = worldObj.getChunk(pos);
       if (worldObj.getChunkProvider() instanceof ChunkProviderServer) {
         List<SpawnDetail> names = new ArrayList<SpawnDetail>();
         for (EnumCreatureType creatureType : EnumCreatureType.values()) {

--- a/src/main/java/com/lothrazar/cyclicmagic/item/enderbook/ItemEnderBook.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/enderbook/ItemEnderBook.java
@@ -156,7 +156,7 @@ public class ItemEnderBook extends BaseItem implements IHasRecipe, IHasConfig {
       //also moving up so  not stuck in floor
       boolean success = UtilEntity.enderTeleportEvent(player, player.world, loc.X, loc.Y + 0.1, loc.Z);
       if (success) { // try and force chunk loading it it worked 
-        player.getEntityWorld().getChunkFromBlockCoords(new BlockPos(loc.X, loc.Y, loc.Z)).setModified(true);
+        player.getEntityWorld().getChunk(new BlockPos(loc.X, loc.Y, loc.Z)).setModified(true);
       }
     }
     return true;

--- a/src/main/java/com/lothrazar/cyclicmagic/item/enderpearl/ItemEnderPearlReuse.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/enderpearl/ItemEnderPearlReuse.java
@@ -63,7 +63,7 @@ public class ItemEnderPearlReuse extends BaseTool implements IHasRecipe {
     playerIn.getCooldownTracker().setCooldown(this, cooldown);
     if (!worldIn.isRemote) {
       EntityEnderPearl entityenderpearl = new EntityEnderPearl(worldIn, playerIn); //func_184538_a
-      entityenderpearl.setHeadingFromThrower(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
+      entityenderpearl.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
       worldIn.spawnEntity(entityenderpearl);
       if (orbType == OrbType.MOUNTED) {
         playerIn.dismountRidingEntity();

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemGloveClimb.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipbauble/ItemGloveClimb.java
@@ -60,7 +60,7 @@ public class ItemGloveClimb extends BaseCharm implements IHasRecipe {
     if (!this.canTick(stack)) {
       return;
     }
-    if (player.isCollidedHorizontally) {
+    if (player.collidedHorizontally) {
       World world = player.getEntityWorld();
       UtilEntity.tryMakeEntityClimb(world, player, CLIMB_SPEED);
       stack.damageItem(1, player);

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipment/ItemGlowingHelmet.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipment/ItemGlowingHelmet.java
@@ -87,7 +87,7 @@ public class ItemGlowingHelmet extends ItemArmor implements IHasRecipe, IHasClic
   @SideOnly(Side.CLIENT)
   @Override
   public void addInformation(ItemStack held, World player, List<String> list, net.minecraft.client.util.ITooltipFlag par4) {
-    list.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    list.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
     String onoff = this.isOn(held) ? "on" : "off";
     list.add(UtilChat.lang("item.cantoggle.tooltip.info") + " " + UtilChat.lang("item.cantoggle.tooltip." + onoff));
     super.addInformation(held, player, list, par4);

--- a/src/main/java/com/lothrazar/cyclicmagic/item/equipment/crystal/ItemPowerSword.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/equipment/crystal/ItemPowerSword.java
@@ -77,7 +77,7 @@ public class ItemPowerSword extends ItemSword implements IHasRecipe, IHasConfig 
   @Override
   public void addInformation(ItemStack stack, World player, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
     if (this.enableShooting) {
-      tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+      tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
     }
     super.addInformation(stack, player, tooltip, advanced);
   }
@@ -121,7 +121,7 @@ public class ItemPowerSword extends ItemSword implements IHasRecipe, IHasConfig 
           if (!world.isRemote) {
             EntityEnderPearl entityenderpearl = new EntityEnderPearl(world, player);
             // - 20
-            entityenderpearl.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, 0.0F, 1.6F, 1.0F);
+            entityenderpearl.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, 1.6F, 1.0F);
             world.spawnEntity(entityenderpearl);
           }
       }
@@ -136,7 +136,7 @@ public class ItemPowerSword extends ItemSword implements IHasRecipe, IHasConfig 
     ItemStack potion = PotionUtils.addPotionToItemStack(new ItemStack(Items.SPLASH_POTION), ptype);
     EntityPotion entitypotion = new EntityPotion(world, player, potion);
     //- 20
-    entitypotion.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, 0, 1.6F, 0.5F);
+    entitypotion.shoot(player, player.rotationPitch, player.rotationYaw, 0, 1.6F, 0.5F);
     if (world.isRemote == false) {
       world.spawnEntity(entitypotion);
     }
@@ -155,6 +155,6 @@ public class ItemPowerSword extends ItemSword implements IHasRecipe, IHasConfig 
 
   @Override
   public void syncConfig(Configuration config) {
-    this.enableShooting = config.getBoolean(this.getUnlocalizedName().replace("item.", "") + "_projectiles", Const.ConfigCategory.modpackMisc, true, "Disable the projectile (splash potion / ender pearl) from this endgame sword");
+    this.enableShooting = config.getBoolean(this.getTranslationKey().replace("item.", "") + "_projectiles", Const.ConfigCategory.modpackMisc, true, "Disable the projectile (splash potion / ender pearl) from this endgame sword");
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/findspawner/EntityDungeonEye.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/findspawner/EntityDungeonEye.java
@@ -92,7 +92,7 @@ public class EntityDungeonEye extends EntityThrowableDispensable {
     this.targetY = pos.getY();
     this.targetZ = pos.getZ();
     this.isLost = false;
-    this.setThrowableHeading(this.targetX, this.targetY, this.targetZ, (this.getGravityVelocity()), 0.01F);
+    this.shoot(this.targetX, this.targetY, this.targetZ, (this.getGravityVelocity()), 0.01F);
   }
 
   public void kill() {

--- a/src/main/java/com/lothrazar/cyclicmagic/item/homingmissile/ItemMagicMissile.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/homingmissile/ItemMagicMissile.java
@@ -85,7 +85,7 @@ public class ItemMagicMissile extends BaseTool implements IHasRecipe {
       //closest actual monster
       EntityLivingBase target = UtilEntity.getClosestEntity(world, player, trimmedTargets);
       EntityHomingProjectile projectile = new EntityHomingProjectile(world, player);
-      projectile.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, 0, 0.5F, 1);
+      projectile.shoot(player, player.rotationPitch, player.rotationYaw, 0, 0.5F, 1);
       projectile.setTarget(target);
       world.spawnEntity(projectile);
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/minecart/BehaviorMinecartDropItem.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/minecart/BehaviorMinecartDropItem.java
@@ -99,9 +99,9 @@ public class BehaviorMinecartDropItem implements IBehaviorDispenseItem {
    */
   public IPosition getDispensePosition(IBlockSource coords) {
     EnumFacing enumfacing = this.getFacing(coords.getBlockState());
-    double d0 = coords.getX() + 0.7D * (double) enumfacing.getFrontOffsetX();
-    double d1 = coords.getY() + 0.7D * (double) enumfacing.getFrontOffsetY();
-    double d2 = coords.getZ() + 0.7D * (double) enumfacing.getFrontOffsetZ();
+    double d0 = coords.getX() + 0.7D * (double) enumfacing.getXOffset();
+    double d1 = coords.getY() + 0.7D * (double) enumfacing.getYOffset();
+    double d2 = coords.getZ() + 0.7D * (double) enumfacing.getZOffset();
     return new PositionImpl(d0, d1, d2);
   }
 
@@ -117,9 +117,9 @@ public class BehaviorMinecartDropItem implements IBehaviorDispenseItem {
     }
     EntityItem entityitem = new EntityItem(worldIn, d0, d1, d2, stack);
     double d3 = worldIn.rand.nextDouble() * 0.1D + 0.2D;
-    entityitem.motionX = (double) facing.getFrontOffsetX() * d3;
+    entityitem.motionX = (double) facing.getXOffset() * d3;
     entityitem.motionY = 0.20000000298023224D;
-    entityitem.motionZ = (double) facing.getFrontOffsetZ() * d3;
+    entityitem.motionZ = (double) facing.getZOffset() * d3;
     entityitem.motionX += worldIn.rand.nextGaussian() * 0.007499999832361937D * (double) speed;
     entityitem.motionY += worldIn.rand.nextGaussian() * 0.007499999832361937D * (double) speed;
     entityitem.motionZ += worldIn.rand.nextGaussian() * 0.007499999832361937D * (double) speed;
@@ -141,6 +141,6 @@ public class BehaviorMinecartDropItem implements IBehaviorDispenseItem {
   }
 
   private int getWorldEventDataFrom(EnumFacing facingIn) {
-    return facingIn.getFrontOffsetX() + 1 + (facingIn.getFrontOffsetZ() + 1) * 3;
+    return facingIn.getXOffset() + 1 + (facingIn.getZOffset() + 1) * 3;
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/minecart/EntityGoldMinecart.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/minecart/EntityGoldMinecart.java
@@ -123,7 +123,7 @@ public class EntityGoldMinecart extends EntityMinecart {
         this.setRollingDirection(-this.getRollingDirection());
         this.setRollingAmplitude(10);
         this.setDamage(50.0F);
-        this.setBeenAttacked();
+        this.markVelocityChanged();
       }
     }
   }

--- a/src/main/java/com/lothrazar/cyclicmagic/item/minecart/EntityMinecartTurret.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/minecart/EntityMinecartTurret.java
@@ -108,7 +108,7 @@ public class EntityMinecartTurret extends EntityGoldMinecart {
     EntityTippedArrow entitytippedarrow = new EntityTippedArrow(world, position.getX(), position.getY(), position.getZ());
     entitytippedarrow.setPotionEffect(PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW), PotionType.getPotionTypeForName("slowness")));
     entitytippedarrow.pickupStatus = EntityArrow.PickupStatus.CREATIVE_ONLY;
-    entitytippedarrow.setThrowableHeading((double) enumfacing.getFrontOffsetX(), YAW, (double) enumfacing.getFrontOffsetZ(), VELOCITY, INACCRACY);
+    entitytippedarrow.shoot((double) enumfacing.getXOffset(), YAW, (double) enumfacing.getZOffset(), VELOCITY, INACCRACY);
     world.spawnEntity(entitytippedarrow);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/item/minecart/FakeWorld.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/minecart/FakeWorld.java
@@ -115,8 +115,8 @@ public class FakeWorld extends World {
   }
 
   @Override
-  public Chunk getChunkFromChunkCoords(int chunkX, int chunkZ) {
-    return this.getCartWorld().getChunkFromChunkCoords(chunkX, chunkZ);
+  public Chunk getChunk(int chunkX, int chunkZ) {
+    return this.getCartWorld().getChunk(chunkX, chunkZ);
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/item/minecart/RenderCyclicMinecart.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/minecart/RenderCyclicMinecart.java
@@ -126,8 +126,8 @@ public class RenderCyclicMinecart<T extends EntityMinecart> extends RenderMineca
       x += vec3d.x - d0;
       y += (vec3d1.y + vec3d2.y) / 2.0D - d1;
       z += vec3d.z - d2;
-      Vec3d vec3d3 = vec3d2.addVector(-vec3d1.x, -vec3d1.y, -vec3d1.z);
-      if (vec3d3.lengthVector() != 0.0D) {
+      Vec3d vec3d3 = vec3d2.add(-vec3d1.x, -vec3d1.y, -vec3d1.z);
+      if (vec3d3.length() != 0.0D) {
         vec3d3 = vec3d3.normalize();
         entityYaw = (float) (Math.atan2(vec3d3.z, vec3d3.x) * 180.0D / Math.PI);
         f3 = (float) (Math.atan(vec3d3.y) * 73.0D);

--- a/src/main/java/com/lothrazar/cyclicmagic/item/mobs/ItemHorseUpgrade.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/mobs/ItemHorseUpgrade.java
@@ -77,7 +77,7 @@ public class ItemHorseUpgrade extends BaseItem implements IHasRecipe {
       return;
     } // just being safe
     Item carrot = stack.getItem();
-    tooltip.add(UtilChat.lang(carrot.getUnlocalizedName(stack) + ".effect"));
+    tooltip.add(UtilChat.lang(carrot.getTranslationKey(stack) + ".effect"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/item/mobs/ItemVillagerMagic.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/mobs/ItemVillagerMagic.java
@@ -122,7 +122,7 @@ public class ItemVillagerMagic extends BaseItem implements IHasRecipe {
   private void startConverting(EntityZombieVillager v, int t) {
     //      v.conversionTime = t;
     ObfuscationReflectionHelper.setPrivateValue(EntityZombieVillager.class, v, t, "conversionTime", "field_82234_d");
-    v.addPotionEffect(new PotionEffect(MobEffects.STRENGTH, t, Math.min(v.world.getDifficulty().getDifficultyId() - 1, 0)));
+    v.addPotionEffect(new PotionEffect(MobEffects.STRENGTH, t, Math.min(v.world.getDifficulty().getId() - 1, 0)));
     v.world.setEntityState(v, (byte) 16);
     try {
       //       v.getDataManager().set(CONVERTING, Boolean.valueOf(true));

--- a/src/main/java/com/lothrazar/cyclicmagic/item/shears/ItemShearsRanged.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/shears/ItemShearsRanged.java
@@ -141,10 +141,10 @@ public class ItemShearsRanged extends BaseItemProjectile implements IHasRecipe {
   }
 
   @Override
-  public float getStrVsBlock(ItemStack stack, IBlockState state) {
+  public float getDestroySpeed(ItemStack stack, IBlockState state) {
     Block block = state.getBlock();
     if (block != Blocks.WEB && state.getMaterial() != Material.LEAVES) {
-      return block == Blocks.WOOL ? 5.0F : super.getStrVsBlock(stack, state);
+      return block == Blocks.WOOL ? 5.0F : super.getDestroySpeed(stack, state);
     }
     else {
       return 15.0F;

--- a/src/main/java/com/lothrazar/cyclicmagic/item/sleep/ItemSleepingMat.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/sleep/ItemSleepingMat.java
@@ -116,7 +116,7 @@ public class ItemSleepingMat extends BaseTool implements IHasRecipe, IHasConfig,
     //hack because vanilla/forge has that java.lang.IllegalArgumentException: Cannot get property PropertyDirection error with assuming its a bed when its blocks.air
     ObfuscationReflectionHelper.setPrivateValue(EntityPlayer.class, player, true, "sleeping", "field_71083_bS");
     ObfuscationReflectionHelper.setPrivateValue(EntityPlayer.class, player, 0, "sleepTimer", "field_71076_b");
-    UtilChat.sendStatusMessage(player, this.getUnlocalizedName() + ".trying");
+    UtilChat.sendStatusMessage(player, this.getTranslationKey() + ".trying");
     //first set bed location
     player.bedLocation = player.getPosition();
     ModCyclic.network.sendTo(new PacketSleepClient(player.bedLocation), player);
@@ -203,8 +203,8 @@ public class ItemSleepingMat extends BaseTool implements IHasRecipe, IHasConfig,
   }
 
   public static void setRenderOffsetForSleep(EntityPlayer mp, EnumFacing fac) {
-    mp.renderOffsetX = -1.8F * fac.getFrontOffsetX();
-    mp.renderOffsetZ = -1.8F * fac.getFrontOffsetZ();
+    mp.renderOffsetX = -1.8F * fac.getXOffset();
+    mp.renderOffsetZ = -1.8F * fac.getZOffset();
     try {
       //stupid private functions in entity player
       Method m = ReflectionHelper.findMethod(Entity.class, "setSize", "func_70105_a", float.class, float.class);

--- a/src/main/java/com/lothrazar/cyclicmagic/item/storagesack/GuiStorage.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/storagesack/GuiStorage.java
@@ -69,7 +69,7 @@ public class GuiStorage extends GuiBaseContainer {
     for (EnumDyeColor color : EnumDyeColor.values()) {
       GuiButtonTooltip buttonColour = new GuiButtonTooltip(color.getColorValue(), x - size, y + size * i,
           size, size, color.name().substring(0, 1));
-      buttonColour.setTooltip(UtilChat.lang("colour." + color.getUnlocalizedName() + ".name"));
+      buttonColour.setTooltip(UtilChat.lang("colour." + color.getTranslationKey() + ".name"));
       buttonColour.packedFGColour = color.getColorValue();
       this.addButton(buttonColour);
       i++;

--- a/src/main/java/com/lothrazar/cyclicmagic/item/tiletransporter/PacketChestSack.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/tiletransporter/PacketChestSack.java
@@ -97,7 +97,7 @@ public class PacketChestSack implements IMessage, IMessageHandler<PacketChestSac
           NBTTagCompound tileData = new NBTTagCompound(); //thanks for the tip on setting tile entity data from nbt tag: https://github.com/romelo333/notenoughwands1.8.8/blob/master/src/main/java/romelo333/notenoughwands/Items/DisplacementWand.java
           tile.writeToNBT(tileData);
           NBTTagCompound itemData = new NBTTagCompound();
-          itemData.setString(ItemChestSack.KEY_BLOCKNAME, state.getBlock().getUnlocalizedName());
+          itemData.setString(ItemChestSack.KEY_BLOCKNAME, state.getBlock().getTranslationKey());
           itemData.setTag(ItemChestSack.KEY_BLOCKTILE, tileData);
           itemData.setInteger(ItemChestSack.KEY_BLOCKID, Block.getIdFromBlock(state.getBlock()));
           itemData.setInteger(ItemChestSack.KEY_BLOCKSTATE, state.getBlock().getMetaFromState(state));

--- a/src/main/java/com/lothrazar/cyclicmagic/item/torchmagic/ItemTorchThrower.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/item/torchmagic/ItemTorchThrower.java
@@ -57,7 +57,7 @@ public class ItemTorchThrower extends BaseTool implements IHasRecipe {
     ItemStack stack = player.getHeldItem(hand);
     if (world.isRemote == false) {
       EntityTorchBolt thing = new EntityTorchBolt(world, player);
-      thing.setHeadingFromThrower(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, VELOCITY_DEFAULT, INACCURACY_DEFAULT);
+      thing.shoot(player, player.rotationPitch, player.rotationYaw, PITCHOFFSET, VELOCITY_DEFAULT, INACCURACY_DEFAULT);
       world.spawnEntity(thing);
     }
     UtilSound.playSound(player, player.getPosition(), SoundEvents.ENTITY_EGG_THROW, SoundCategory.PLAYERS);

--- a/src/main/java/com/lothrazar/cyclicmagic/module/LootTableModule.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/module/LootTableModule.java
@@ -126,7 +126,7 @@ public class LootTableModule extends BaseEventModule implements IHasConfig {
   //  }
   private void addLoot(LootPool main, Item item, int rando) {
     if (item != null) {//shortcut fix bc of new module config system that can delete items   
-      main.addEntry(new LootEntryItem(item, rando, 0, new LootFunction[0], new LootCondition[0], Const.MODRES + item.getUnlocalizedName()));
+      main.addEntry(new LootEntryItem(item, rando, 0, new LootFunction[0], new LootCondition[0], Const.MODRES + item.getTranslationKey()));
     }
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/net/PacketSound.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/net/PacketSound.java
@@ -51,8 +51,8 @@ public class PacketSound implements IMessage, IMessageHandler<PacketSound, IMess
   public PacketSound(BlockPos p, SoundEvent t, SoundCategory cat) {
     pos = p;
     ResourceLocation r = t.getRegistryName();
-    domain = r.getResourceDomain();
-    type = r.getResourcePath();
+    domain = r.getNamespace();
+    type = r.getPath();
     category = cat.getName(); //SoundCategory.BLOCKS.getName()
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemAppleStep.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemAppleStep.java
@@ -110,7 +110,7 @@ public class ItemAppleStep extends ItemFoodCreative implements IHasRecipe, IHasC
   @SideOnly(Side.CLIENT)
   @Override
   public void addInformation(ItemStack stack, World player, List<String> tooltip, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
     super.addInformation(stack, player, tooltip, advanced);
   }
 

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemCraftingUnlock.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemCraftingUnlock.java
@@ -77,6 +77,6 @@ public class ItemCraftingUnlock extends ItemFoodCreative implements IHasRecipe {
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltips, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltips.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltips.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemFlight.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemFlight.java
@@ -112,7 +112,7 @@ public class ItemFlight extends ItemFoodCreative implements IHasRecipe {
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltips, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltips.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltips.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemHeartContainer.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemHeartContainer.java
@@ -119,7 +119,7 @@ public class ItemHeartContainer extends ItemFoodCreative implements IHasRecipe, 
 
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, EntityPlayer playerIn, List<String> tooltip, boolean advanced) {
-    tooltip.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltip.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemInventoryUnlock.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemInventoryUnlock.java
@@ -86,6 +86,6 @@ public class ItemInventoryUnlock extends ItemFoodCreative implements IHasRecipe,
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltips, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltips.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltips.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 }

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemNoclipGhost.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/ItemNoclipGhost.java
@@ -70,7 +70,7 @@ public class ItemNoclipGhost extends ItemFoodCreative implements IHasRecipe, IHa
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack stack, World playerIn, List<String> tooltips, net.minecraft.client.util.ITooltipFlag advanced) {
-    tooltips.add(UtilChat.lang(this.getUnlocalizedName() + ".tooltip"));
+    tooltips.add(UtilChat.lang(this.getTranslationKey() + ".tooltip"));
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/PlayerAbilitiesModule.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/PlayerAbilitiesModule.java
@@ -84,7 +84,7 @@ public class PlayerAbilitiesModule extends BaseEventModule implements IHasConfig
       //removed  && entityPlayer.isSneaking() == false
       if (state != null && (state.getBlock() == Blocks.WALL_SIGN || state.getBlock() == Blocks.WALL_BANNER)) {
         // but NOT standing sign or standing banner
-        EnumFacing face = EnumFacing.getFront(state.getBlock().getMetaFromState(state));
+        EnumFacing face = EnumFacing.byIndex(state.getBlock().getMetaFromState(state));
         BlockPos posBehind = pos.offset(face.getOpposite());
         IBlockState stuffBehind = worldObj.getBlockState(posBehind);
         if (stuffBehind != null && stuffBehind.getBlock() != null && worldObj.getTileEntity(posBehind) != null) {

--- a/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/crafting/InventoryPlayerExtWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/playerupgrade/crafting/InventoryPlayerExtWorkbench.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import com.lothrazar.cyclicmagic.core.util.Const;
 import com.lothrazar.cyclicmagic.core.util.UtilNBT;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -38,12 +39,12 @@ import net.minecraft.util.text.TextComponentTranslation;
 public class InventoryPlayerExtWorkbench extends InventoryCrafting {
 
   protected NonNullList<ItemStack> inv;
-  private ContainerPlayerExtWorkbench eventHandler;
+  private Container eventHandler;
   public WeakReference<EntityPlayer> player;
   public static final int IROW = 3;
   public static final int ICOL = 3;
 
-  public InventoryPlayerExtWorkbench(ContainerPlayerExtWorkbench containerPlayerExtWorkbench, EntityPlayer player) {
+  public InventoryPlayerExtWorkbench(Container containerPlayerExtWorkbench, EntityPlayer player) {
     super(containerPlayerExtWorkbench, 3, 3);
     this.eventHandler = containerPlayerExtWorkbench;
     inv = NonNullList.withSize(IROW * ICOL + 5, ItemStack.EMPTY);//5 armor + 3x3

--- a/src/main/java/com/lothrazar/cyclicmagic/registry/BlockRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/registry/BlockRegistry.java
@@ -65,7 +65,7 @@ public class BlockRegistry {
       b.setCreativeTab(ModCyclic.TAB);
     }
     b.setRegistryName(new ResourceLocation(Const.MODID, name));
-    b.setUnlocalizedName(name);
+    b.setTranslationKey(name);
     if (b instanceof IHasConfig) {
       ConfigRegistry.register((IHasConfig) b);
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/registry/ItemRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/registry/ItemRegistry.java
@@ -65,7 +65,7 @@ public class ItemRegistry {
   public static List<Item> itemList = new ArrayList<Item>();
 
   public static void register(Item item, String key, GuideCategory cat) {
-    item.setUnlocalizedName(key);
+    item.setTranslationKey(key);
     item.setRegistryName(new ResourceLocation(Const.MODID, key));
     itemList.add(item);
     item.setCreativeTab(ModCyclic.TAB);
@@ -141,7 +141,7 @@ public class ItemRegistry {
       if (item instanceof ItemBlock) {
         continue;
       }
-      name = Const.MODRES + item.getUnlocalizedName().replaceAll("item.", "");
+      name = Const.MODRES + item.getTranslationKey().replaceAll("item.", "");
       ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(name, "inventory"));
     }
     Item item;
@@ -149,12 +149,12 @@ public class ItemRegistry {
       item = Item.getItemFromBlock(b);
       if (b instanceof BlockCableBase) {
         ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(
-            new ResourceLocation(Const.MODID, b.getUnlocalizedName().replaceAll("tile.", "")), "inventory"));
+            new ResourceLocation(Const.MODID, b.getTranslationKey().replaceAll("tile.", "")), "inventory"));
         ModelLoader.setCustomStateMapper(b, STATE_MAPPER);
         //TODO: CABLE REGISTRY OR SOMETHING
         continue;
       }
-      name = Const.MODRES + b.getUnlocalizedName().replaceAll("tile.", "");
+      name = Const.MODRES + b.getTranslationKey().replaceAll("tile.", "");
       ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(name, "inventory"));
       ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(name));
       if (b instanceof IBlockHasTESR) {

--- a/src/main/java/com/lothrazar/cyclicmagic/registry/MaterialRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/registry/MaterialRegistry.java
@@ -91,8 +91,8 @@ public class MaterialRegistry { // thanks for help:
     MaterialRegistry.powerToolMaterial = EnumHelper.addToolMaterial(MATERIALNAME,
         ToolMaterial.DIAMOND.getHarvestLevel(),
         ToolMaterial.DIAMOND.getMaxUses() * 4, //was  - 261
-        ToolMaterial.DIAMOND.getEfficiencyOnProperMaterial(),
-        ToolMaterial.DIAMOND.getDamageVsEntity() * 8, //best draconic evolution sword is 35 base, so this is not that crazy
+        ToolMaterial.DIAMOND.getEfficiency(),
+        ToolMaterial.DIAMOND.getAttackDamage() * 8, //best draconic evolution sword is 35 base, so this is not that crazy
         ToolMaterial.GOLD.getEnchantability() * 2);
     MaterialRegistry.powerToolMaterial.setRepairItem(MaterialRegistry.powerArmorMaterial.repairMaterial);
   }
@@ -115,8 +115,8 @@ public class MaterialRegistry { // thanks for help:
     MaterialRegistry.emeraldToolMaterial = EnumHelper.addToolMaterial(emeraldName,
         ToolMaterial.DIAMOND.getHarvestLevel(),
         ToolMaterial.DIAMOND.getMaxUses(), //was  - 261
-        ToolMaterial.DIAMOND.getEfficiencyOnProperMaterial(),
-        ToolMaterial.DIAMOND.getDamageVsEntity(), //was  - 0.25F
+        ToolMaterial.DIAMOND.getEfficiency(),
+        ToolMaterial.DIAMOND.getAttackDamage(), //was  - 0.25F
         ToolMaterial.GOLD.getEnchantability());
     MaterialRegistry.emeraldToolMaterial.setRepairItem(MaterialRegistry.emeraldArmorMaterial.repairMaterial);
   }
@@ -128,8 +128,8 @@ public class MaterialRegistry { // thanks for help:
     MaterialRegistry.sandstoneToolMaterial = EnumHelper.addToolMaterial("sandstone",
         ToolMaterial.STONE.getHarvestLevel(),
         (ToolMaterial.STONE.getMaxUses() + ToolMaterial.WOOD.getMaxUses()) / 2,
-        (ToolMaterial.STONE.getEfficiencyOnProperMaterial() + ToolMaterial.STONE.getEfficiencyOnProperMaterial()) / 2,
-        (ToolMaterial.STONE.getDamageVsEntity() + ToolMaterial.WOOD.getDamageVsEntity()) / 2.0F,
+        (ToolMaterial.STONE.getEfficiency() + ToolMaterial.STONE.getEfficiency()) / 2,
+        (ToolMaterial.STONE.getAttackDamage() + ToolMaterial.WOOD.getAttackDamage()) / 2.0F,
         ToolMaterial.GOLD.getEnchantability());
     MaterialRegistry.sandstoneToolMaterial.setRepairItem(new ItemStack(Blocks.SANDSTONE));
   }
@@ -141,9 +141,9 @@ public class MaterialRegistry { // thanks for help:
     MaterialRegistry.netherToolMaterial = EnumHelper.addToolMaterial("nether",
         ToolMaterial.STONE.getHarvestLevel(),
         (ToolMaterial.STONE.getMaxUses() + ToolMaterial.IRON.getMaxUses()) / 2,
-        (ToolMaterial.STONE.getEfficiencyOnProperMaterial() + //halfway in between
-            ToolMaterial.IRON.getEfficiencyOnProperMaterial()) / 2,
-        ToolMaterial.IRON.getDamageVsEntity(),
+        (ToolMaterial.STONE.getEfficiency() + //halfway in between
+            ToolMaterial.IRON.getEfficiency()) / 2,
+        ToolMaterial.IRON.getAttackDamage(),
         ToolMaterial.GOLD.getEnchantability());
     MaterialRegistry.netherToolMaterial.setRepairItem(new ItemStack(Items.NETHERBRICK));
   }

--- a/src/main/java/com/lothrazar/cyclicmagic/registry/RecipeRegistry.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/registry/RecipeRegistry.java
@@ -85,12 +85,12 @@ public class RecipeRegistry {
   public static class Util1pt12 {
 
     public static ResourceLocation buildName(ItemStack output) {
-      ResourceLocation firstTry = new ResourceLocation(Const.MODID, output.getUnlocalizedName());
+      ResourceLocation firstTry = new ResourceLocation(Const.MODID, output.getTranslationKey());
       int limit = 999;
       int index = 0;
       while (usedRecipeNames.containsKey(firstTry.toString()) || index > limit) {
         index++;
-        firstTry = new ResourceLocation(Const.MODID, firstTry.getResourcePath() + "_" + index);
+        firstTry = new ResourceLocation(Const.MODID, firstTry.getPath() + "_" + index);
       }
       usedRecipeNames.put(firstTry.toString(), true);
       return firstTry;
@@ -157,7 +157,7 @@ public class RecipeRegistry {
       }
     }
     ResourceLocation location = Util1pt12.buildName(output);
-    ShapelessRecipes recipe = new ShapelessRecipes(location.getResourceDomain(), output, Util1pt12.convertToNonNullList(recipeComponents));
+    ShapelessRecipes recipe = new ShapelessRecipes(location.getNamespace(), output, Util1pt12.convertToNonNullList(recipeComponents));
     add(recipe, location);
     return recipe;
   }
@@ -223,9 +223,9 @@ public class RecipeRegistry {
     if (ModCyclic.logger.runUnitTests()) {//OMG UNIT TESTING WAAT
       ItemStack output0 = BrewingRecipeRegistry.getOutput(input, ingredient);
       if (output0.getItem() == output.getItem())
-        ModCyclic.logger.logTestResult("Brewing Recipe succefully registered and working: " + output.getUnlocalizedName());
+        ModCyclic.logger.logTestResult("Brewing Recipe succefully registered and working: " + output.getTranslationKey());
       else {
-        ModCyclic.logger.logTestResult("Brewing Recipe FAILED to register" + output.getUnlocalizedName());
+        ModCyclic.logger.logTestResult("Brewing Recipe FAILED to register" + output.getTranslationKey());
       }
     }
     return recipe;

--- a/src/main/java/com/lothrazar/cyclicmagic/tweak/MobChangesModule.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/tweak/MobChangesModule.java
@@ -90,7 +90,7 @@ public class MobChangesModule extends BaseEventModule implements IHasConfig {
           EntityEnderman.setCarriable(registeredBlock, false);
         }
         catch (Exception e) {
-          ModCyclic.logger.error("MobChangesModule: error trying to disable enderman pickup ability on ", registeredBlock.getUnlocalizedName());
+          ModCyclic.logger.error("MobChangesModule: error trying to disable enderman pickup ability on ", registeredBlock.getTranslationKey());
           e.printStackTrace();
         }
       }

--- a/src/main/java/com/lothrazar/cyclicmagic/tweak/StackSizeModule.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/tweak/StackSizeModule.java
@@ -78,7 +78,7 @@ public class StackSizeModule extends BaseModule implements IHasConfig {
   public void syncConfig(Configuration config) {
     String category = Const.ConfigCategory.itemsTack;
     for (Map.Entry<Item, Integer> entry : stackMap.entrySet()) {
-      String name = entry.getKey().getUnlocalizedName();
+      String name = entry.getKey().getTranslationKey();
       int enabled = config.getBoolean(name, category, true, "Increase stack size to " + entry.getValue()) ? 1 : 0;
       enabledMap.put(entry.getKey(), enabled);
     }

--- a/src/main/java/com/lothrazar/cyclicmagic/tweak/TextInfoModule.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/tweak/TextInfoModule.java
@@ -124,7 +124,7 @@ public class TextInfoModule extends BaseEventModule implements IHasConfig {
      * of a chunk, 17 chunks will be loaded along that axis, of which 13 activate entities. */
     BlockPos spawn = player.getEntityWorld().getSpawnPoint();
     BlockPos here = player.getPosition();
-    Chunk chunkHere = player.getEntityWorld().getChunkFromBlockCoords(here);
+    Chunk chunkHere = player.getEntityWorld().getChunk(here);
     int xCenterOfChunk = UtilWorld.chunkToBlock(chunkHere.x) + Const.CHUNK_SIZE / 2;
     int zCenterOfChunk = UtilWorld.chunkToBlock(chunkHere.z) + Const.CHUNK_SIZE / 2;
     //end border


### PR DESCRIPTION
This PR ended up quite a bit larger than it needed to be, since for whatever reason crafttweaker requires newer mappings now.

Aside from the giant mappings update commit, FastBench compat has been added for the extended player inventory grid and the cyclic workbench.  This dependency is optional, so users without FastWorkbench won't notice anything,.

I'll be making a similar PR to Simple Storage Network soon as well.