### PR TITLE
Fix sideness issue with Life Leech enchant

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantLifeLeech.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantLifeLeech.java
@@ -81,8 +81,7 @@ public class EnchantLifeLeech extends BaseEnchant {
         restore = attacker.getEntityWorld().rand.nextInt(restore + 1) + min;
         if (restore > 0) {
           //hunger
-          attacker.getFoodStats().setFoodLevel(attacker.getFoodStats().getFoodLevel() + restore);
-          attacker.getFoodStats().setFoodSaturationLevel(attacker.getFoodStats().getSaturationLevel() + restore);
+          attacker.getFoodStats().addStats(restore, 0.5F);
           //hearts
           if (attacker.getHealth() < attacker.getMaxHealth()) {
             attacker.heal(restore);


### PR DESCRIPTION
`setFoodSaturationLevel` is client side only and so when killing mobs with a Life Leech weapon on a dedicated server this prevented loot from dropping because of the resulting exception.

This fixes #924 and also makes the hunger regen from Life Leech respect the vanilla food hard caps. The amount of hunger/saturation restored is the same as before.