### PR TITLE
Fix Phantom Growths on client.

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/block/sprinkler/TileSprinkler.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/sprinkler/TileSprinkler.java
@@ -92,7 +92,9 @@ public class TileSprinkler extends TileEntityBaseMachineInvo implements ITickabl
           }
           try {//no need to literally increase internal growth numbers, just force more  update ticks
             world.scheduleBlockUpdate(current, block, world.rand.nextInt(TICKS) + 20, 1);
-            block.updateTick(world, current, bState, world.rand);
+            if ( ! world.isRemote ) {
+            	block.updateTick(world, current, bState, world.rand);
+            }
           }
           catch (Exception e) {
             ModCyclic.logger.error("Sprinkler by Cyclic has encountered an error while growing a plant, contact both mod authors    " + block);


### PR DESCRIPTION
Issue, plants will grown on the client side and not on the server, this causes de-sync.

I fixed this by simply not calling Block.updateTick on the client, I tested this before and after with cactus and it seems to fix the issue.