### PR TITLE
Optimize BaseEnchant calls to EnchantmentHelper and HashMap

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/enchant/BaseEnchant.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/enchant/BaseEnchant.java
@@ -31,6 +31,8 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 
+import java.util.Map;
+
 public abstract class BaseEnchant extends Enchantment implements IContent {
 
   protected BaseEnchant(String name, Rarity rarityIn, EnumEnchantmentType typeIn, EntityEquipmentSlot[] slots) {
@@ -44,8 +46,12 @@ public abstract class BaseEnchant extends Enchantment implements IContent {
   }
 
   protected int getCurrentLevelTool(ItemStack stack) {
-    if (stack.isEmpty() == false && EnchantmentHelper.getEnchantments(stack).containsKey(this))
-      return EnchantmentHelper.getEnchantments(stack).get(this);
+    if (!stack.isEmpty()) {
+      Integer enchantment = EnchantmentHelper.getEnchantments(stack).get(this);
+      if (enchantment != null) {
+        return enchantment;
+      }
+    }
     return -1;
   }
 
@@ -65,11 +71,10 @@ public abstract class BaseEnchant extends Enchantment implements IContent {
     int level = 0;
     for (EntityEquipmentSlot slot : armors) {
       ItemStack armor = player.getItemStackFromSlot(slot);
-      if (armor.isEmpty() == false
-          && EnchantmentHelper.getEnchantments(armor) != null
-          && EnchantmentHelper.getEnchantments(armor).containsKey(this)) {
-        int newlevel = EnchantmentHelper.getEnchantments(armor).get(this);
-        if (newlevel > level) {
+      if (!armor.isEmpty()) {
+        Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(armor);
+        Integer newlevel = enchantments.get(this);
+        if (newlevel != null && newlevel > level) {
           level = newlevel;
         }
       }
@@ -86,7 +91,7 @@ public abstract class BaseEnchant extends Enchantment implements IContent {
       return ItemStack.EMPTY;
     }
     for (ItemStack main : player.getArmorInventoryList()) {
-      if ((main.isEmpty() == false) &&
+      if ((!main.isEmpty()) &&
           EnchantmentHelper.getEnchantments(main).containsKey(this)) {
         return main;// EnchantmentHelper.getEnchantments(main).get(this);
       }

--- a/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantLaunch.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/enchant/EnchantLaunch.java
@@ -25,6 +25,8 @@ package com.lothrazar.cyclicmagic.enchant;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+
 import com.lothrazar.cyclicmagic.ModCyclic;
 import com.lothrazar.cyclicmagic.guide.GuideRegistry;
 import com.lothrazar.cyclicmagic.net.PacketPlayerFalldamage;
@@ -36,6 +38,7 @@ import com.lothrazar.cyclicmagic.util.UtilItemStack;
 import com.lothrazar.cyclicmagic.util.UtilNBT;
 import com.lothrazar.cyclicmagic.util.UtilParticle;
 import com.lothrazar.cyclicmagic.util.UtilSound;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.entity.item.EntityBoat;
@@ -132,7 +135,9 @@ public class EnchantLaunch extends BaseEnchant {
     if (feet == null || feet.isEmpty() || player.isSneaking()) {
       return;
     } //sneak to not double jump
-    if (EnchantmentHelper.getEnchantments(feet).containsKey(this) == false) {
+    Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(feet);
+    Integer level = enchantments.get(this);
+    if (level == null) {
       return;
     }
     if (player.getCooldownTracker().hasCooldown(feet.getItem())) {
@@ -141,7 +146,6 @@ public class EnchantLaunch extends BaseEnchant {
     if (FMLClientHandler.instance().getClient().gameSettings.keyBindJump.isKeyDown()
         && player.posY < player.lastTickPosY && player.isAirBorne && player.isInWater() == false) {
       //JUMP IS pressed and you are moving down
-      int level = EnchantmentHelper.getEnchantments(feet).get(this);
       int uses = UtilNBT.getItemStackNBTVal(feet, NBT_USES);
       player.fallDistance = 0;
       float angle = (player.motionX == 0 && player.motionZ == 0) ? 90 : ROTATIONPITCH;


### PR DESCRIPTION
Via profiling my server, I noticed that this area of code was one of the more time-consuming per tick. I was able to reduce the amount of calls to EnchantmentHelper, and fixed some HashMap patterns (containsKey and get -> get and null check).

Screenshot from my profiler (warmroast), notice how it is the hottest onEntityUpdate event handler.

![image](https://user-images.githubusercontent.com/196978/90326167-b4ac8300-df4a-11ea-8d83-078e8b64014b.png)

I was not able to build the project due to some api not existing errors but IntelliJ seems happy with this code. So please double-check me, and let me know if you have questions.

CC @NillerMedDild since this is in Enigmatica 2 Expert 1.81a modpack.