### PR TITLE
[1.16] Add missing functionality to Experience Pylon

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/expcollect/BlockExpPylon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/expcollect/BlockExpPylon.java
@@ -1,16 +1,30 @@
 package com.lothrazar.cyclic.block.expcollect;
 
 import com.lothrazar.cyclic.base.BlockBase;
+import com.lothrazar.cyclic.fluid.FluidXpJuiceHolder;
 import com.lothrazar.cyclic.registry.ContainerScreenRegistry;
+import com.lothrazar.cyclic.registry.ItemRegistry;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.RenderTypeLookup;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class BlockExpPylon extends BlockBase {
 
@@ -34,5 +48,31 @@ public class BlockExpPylon extends BlockBase {
   @Override
   public TileEntity createTileEntity(BlockState state, IBlockReader world) {
     return new TileExpPylon();
+  }
+
+  @Override
+  public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult result) {
+    if (!world.isRemote) {
+      TileExpPylon pylon = (TileExpPylon) world.getTileEntity(pos);
+      int fluidPerAction = ExpItemGain.EXP_PER_FOOD * ExpItemGain.FLUID_PER_EXP;
+      if (player.getHeldItemMainhand().getItem() == Items.SUGAR) {
+        if (pylon.tank.getFluidAmount() >= fluidPerAction) {
+          pylon.tank.drain(fluidPerAction, IFluidHandler.FluidAction.EXECUTE);
+          player.addItemStackToInventory(new ItemStack(ItemRegistry.experience_food, 1));
+          player.getHeldItemMainhand().shrink(1);
+          world.playSound((PlayerEntity)null, pos, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.NEUTRAL, 0.5F, world.rand.nextFloat());
+        }
+        return ActionResultType.SUCCESS;
+      }
+      else if (player.getHeldItemMainhand().getItem() == ItemRegistry.experience_food) {
+        if (pylon.tank.getFluidAmount() + fluidPerAction < pylon.tank.getCapacity()) {
+          pylon.tank.fill(new FluidStack(FluidXpJuiceHolder.STILL.get(), fluidPerAction), IFluidHandler.FluidAction.EXECUTE);
+          player.getHeldItemMainhand().shrink(1);
+          world.playSound((PlayerEntity)null, pos, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.NEUTRAL, 0.2F, world.rand.nextFloat());
+        }
+        return ActionResultType.SUCCESS;
+      }
+    }
+    return super.onBlockActivated(state, world, pos, player, hand, result);
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/expcollect/ExpItemGain.java
+++ b/src/main/java/com/lothrazar/cyclic/block/expcollect/ExpItemGain.java
@@ -2,9 +2,12 @@ package com.lothrazar.cyclic.block.expcollect;
 
 import com.lothrazar.cyclic.base.ItemBase;
 import com.lothrazar.cyclic.util.UtilSound;
-import net.minecraft.item.ItemUseContext;
-import net.minecraft.util.ActionResultType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.world.World;
 
 public class ExpItemGain extends ItemBase {
 
@@ -17,10 +20,12 @@ public class ExpItemGain extends ItemBase {
   }
 
   @Override
-  public ActionResultType onItemUse(ItemUseContext context) {
-    context.getPlayer().giveExperiencePoints(EXP_PER_FOOD);
-    context.getPlayer().getHeldItem(context.getHand()).shrink(1);
-    UtilSound.playSound(context.getPlayer(), SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP);
-    return super.onItemUse(context);
+  public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn) {
+    if (!worldIn.isRemote && handIn == Hand.MAIN_HAND) {
+      playerIn.giveExperiencePoints(EXP_PER_FOOD);
+      playerIn.getHeldItemMainhand().shrink(1);
+      UtilSound.playSound(playerIn, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP);
+    }
+    return super.onItemRightClick(worldIn, playerIn, handIn);
   }
 }


### PR DESCRIPTION
- Added ability to use sugar on an Experience Pylon to get an Experience Confection, as indicated by the tooltip of Experience Confection
- Added ability to use Experience Confection on an Experience Pylon to put the experience in the Confection back into the Pylon
- Changed onItemUse to onItemRightClick for Experience Confection, allowing the item to be consumed regardless of what was clicked (previously would only be consumed if clicking on a block)