### PR TITLE
[1.16] Store UUID of User (the tile entity, not the player) in NBT

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
+++ b/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
@@ -117,8 +117,8 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
     //    return result;
   }
 
-  public WeakReference<FakePlayer> setupBeforeTrigger(ServerWorld sw, String name) {
-    WeakReference<FakePlayer> fakePlayer = UtilFakePlayer.initFakePlayer(sw, UUID.randomUUID(), name);
+  public WeakReference<FakePlayer> setupBeforeTrigger(ServerWorld sw, String name, UUID uuid) {
+    WeakReference<FakePlayer> fakePlayer = UtilFakePlayer.initFakePlayer(sw, uuid, name);
     if (fakePlayer == null) {
       ModCyclic.LOGGER.error("Fake player failed to init ");
       return null;
@@ -127,6 +127,10 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
     fakePlayer.get().setPosition(this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());//seems to help interact() mob drops like milk
     fakePlayer.get().rotationYaw = UtilEntity.getYawFromFacing(this.getCurrentFacing());
     return fakePlayer;
+  }
+
+  public WeakReference<FakePlayer> setupBeforeTrigger(ServerWorld sw, String name) {
+    return setupBeforeTrigger(sw, name, UUID.randomUUID());
   }
 
   public void setLitProperty(boolean lit) {


### PR DESCRIPTION
Store UUID of User (the tile entity, not the player) in NBT
Refactor TileEntityBase.setupBeforeTrigger to accept a predefined UUID instead of always making a random one. Left the original method as well -- it just calls the new version with a random UUID.

Resolves issue #1495 