### PR TITLE
[1.12] Fix Pattern Replicator to not cause out of bounds exception

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/block/builderpattern/TileEntityPatternBuilder.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/builderpattern/TileEntityPatternBuilder.java
@@ -183,7 +183,7 @@ public class TileEntityPatternBuilder extends TileEntityBaseMachineInvo implemen
       timer = 0;
       List<BlockPos> shapeSrc = this.getSourceShape();
       List<BlockPos> shapeTarget = this.getTargetShape();
-      if (shapeSrc.size() <= 0) {
+      if (shapeSrc.size() <= 0 || shapeTarget.size() <= 0) {
         return;
       }
       if (this.shapeIndex < 0 || this.shapeIndex >= shapeSrc.size()) {


### PR DESCRIPTION
Fix Pattern Replicator to not cause out of bounds exception when two source GPS Markers are present in the GUI without a target GPS Marker.

Resolves issue #1480 