### PR TITLE
Fix compatibility issue with added hearts

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
+++ b/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
@@ -4,6 +4,7 @@ import com.lothrazar.cyclic.base.ItemEntityInteractable;
 import com.lothrazar.cyclic.block.cable.CableWrench;
 import com.lothrazar.cyclic.block.cable.WrenchActionType;
 import com.lothrazar.cyclic.block.scaffolding.ItemScaffolding;
+import com.lothrazar.cyclic.item.HeartItem;
 import com.lothrazar.cyclic.item.builder.BuilderActionType;
 import com.lothrazar.cyclic.item.builder.BuilderItem;
 import com.lothrazar.cyclic.registry.BlockRegistry;
@@ -15,6 +16,7 @@ import com.lothrazar.cyclic.util.UtilSound;
 import com.lothrazar.cyclic.util.UtilWorld;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
@@ -37,7 +39,9 @@ public class ItemEvents {
   public void onPlayerCloneDeath(PlayerEvent.Clone event) {
     ModifiableAttributeInstance original = event.getOriginal().getAttribute(Attributes.MAX_HEALTH);
     if (original != null) {
-      UtilEntity.setMaxHealth(event.getPlayer(), original.getValue());
+      AttributeModifier healthModifier = original.getModifier(HeartItem.healthModifierUuid);
+      if (healthModifier != null)
+        event.getPlayer().getAttribute(Attributes.MAX_HEALTH).applyPersistentModifier(healthModifier);
     }
   }
   //

--- a/src/main/java/com/lothrazar/cyclic/item/HeartItem.java
+++ b/src/main/java/com/lothrazar/cyclic/item/HeartItem.java
@@ -4,16 +4,20 @@ import com.lothrazar.cyclic.base.ItemBase;
 import com.lothrazar.cyclic.registry.SoundRegistry;
 import com.lothrazar.cyclic.util.UtilEntity;
 import com.lothrazar.cyclic.util.UtilSound;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemUseContext;
 import net.minecraft.util.ActionResultType;
 
+import java.util.UUID;
+
 public class HeartItem extends ItemBase {
 
   private static final int MAX = 100;
   private static final int COOLDOWN = 5000;
+  public static final UUID healthModifierUuid = UUID.fromString("06d30aa2-eff2-4a81-b92b-a1cb95f115c6");
 
   public HeartItem(Properties properties) {
     super(properties);
@@ -23,13 +27,23 @@ public class HeartItem extends ItemBase {
   @Override
   public ActionResultType onItemUse(ItemUseContext context) {
     PlayerEntity player = context.getPlayer();
+    double addedHealth = 0.0D;
     if (player.getCooldownTracker().hasCooldown(this)) {
       return super.onItemUse(context);
     }
     player.getFoodStats().addStats(1, 4);
     ModifiableAttributeInstance healthAttribute = player.getAttribute(Attributes.MAX_HEALTH);
+
     if (healthAttribute.getValue() < MAX) {
-      UtilEntity.incrementMaxHealth(player, 2);
+      try {
+        AttributeModifier oldHealthModifier = healthAttribute.getModifier(healthModifierUuid);
+        addedHealth = oldHealthModifier.getAmount() + 4.0D;
+        healthAttribute.removeModifier(healthModifierUuid);
+      } catch (NullPointerException e) {
+        addedHealth = 4.0D;
+      }
+      AttributeModifier healthModifier = new AttributeModifier(healthModifierUuid, "HP Bonus from Cyclic", addedHealth, AttributeModifier.Operation.ADDITION);
+      healthAttribute.applyPersistentModifier(healthModifier);
       player.getCooldownTracker().setCooldown(this, COOLDOWN);
       player.getHeldItem(context.getHand()).shrink(1);
       UtilSound.playSound(player, SoundRegistry.fill);


### PR DESCRIPTION
Fix compatibility issue where dying with extra hearts added by any other mod can potentially cause Cyclic to add additional hearts to the player on death.

Explanation: Cyclic was only adding hearts directly to the health attribute and not tracking it via an `AttributeModifier`. When any other mod adjusted the `Attributes.MAX_HEALTH` of the player and restored its added `MAX_HEALTH` upon death, Cyclic would "double up" and also restore the same number of hearts regardless of if it had added extra hearts to the player via the `HeartItem`.

This was reported in issue #1474 as a compatibility issue with Project MMO.

The fix: With inspiration from the information provided by the mod dev via the screenshot in the linked issue, Cyclic now tracks its own `AttributeModifier` for health and will only restore the hearts that have been added by this mod.

TODO: Probably need to look at the `ToxicHeart` as well and make the same changes.