### PR TITLE
[1.16] bugfixes for Fluid Collector

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/ConfigManager.java
+++ b/src/main/java/com/lothrazar/cyclic/ConfigManager.java
@@ -9,6 +9,7 @@ import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.lothrazar.cyclic.block.anvil.TileAnvilAuto;
 import com.lothrazar.cyclic.block.beaconpotion.TilePotion;
+import com.lothrazar.cyclic.block.collectfluid.TileFluidCollect;
 import com.lothrazar.cyclic.block.disenchant.TileDisenchant;
 import com.lothrazar.cyclic.block.dropper.TileDropper;
 import com.lothrazar.cyclic.block.forester.TileForester;
@@ -125,6 +126,7 @@ public class ConfigManager {
     TilePotion.POWERCONF = CFG.comment("Power per tick").defineInRange(category + "beacon", 10, 0, 64000);
     TileMiner.POWERCONF = CFG.comment("Power per use").defineInRange(category + "miner", 10, 0, 64000);
     TileUncraft.POWERCONF = CFG.comment("Power per use").defineInRange(category + "uncraft", 1000, 0, 64000);
+    TileFluidCollect.POWERCONF = CFG.comment("Power per use").defineInRange(category + "collector_fluid", 500, 0, 64000);
     category = "peat.";
     PEATCHANCE = CFG.comment("Chance that Peat Bog converts to Peat when wet (is multiplied by the number of surrounding water blocks)")
         .defineInRange(category + "conversionChance",

--- a/src/main/java/com/lothrazar/cyclic/block/collectfluid/BlockFluidCollect.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectfluid/BlockFluidCollect.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
@@ -47,7 +48,7 @@ public class BlockFluidCollect extends BlockBase {
   @Override
   public void onBlockPlacedBy(World world, BlockPos pos, BlockState state, @Nullable LivingEntity entity, ItemStack stack) {
     if (entity != null) {
-      world.setBlockState(pos, state.with(BlockStateProperties.HORIZONTAL_FACING, UtilStuff.getFacingFromEntity(pos, entity)), 2);
+      world.setBlockState(pos, state.with(BlockStateProperties.HORIZONTAL_FACING, UtilStuff.getFacingFromEntityHorizontal(pos, entity)), 2);
     }
   }
 

--- a/src/main/java/com/lothrazar/cyclic/block/collectfluid/BlockFluidCollect.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectfluid/BlockFluidCollect.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.client.registry.ClientRegistry;
 public class BlockFluidCollect extends BlockBase {
 
   public BlockFluidCollect(Properties properties) {
-    super(properties);
+    super(properties.hardnessAndResistance(1.8F));
     this.setHasGui();
   }
 

--- a/src/main/resources/data/cyclic/loot_tables/blocks/collector_fluid.json
+++ b/src/main/resources/data/cyclic/loot_tables/blocks/collector_fluid.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "cyclic:collector_fluid"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the following:

- Missing hardness property causing the block to break instantly
- Missing loot table causing the block to not drop itself
- Null pointer crash when accessing the GUI due to POWERCONF not being set in Config
- Crash when placing the Collector while facing UP or DOWN (only horizontal facings are allowed)