### PR TITLE
[1.16] Port Peat Farm from 1.12

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/ConfigManager.java
+++ b/src/main/java/com/lothrazar/cyclic/ConfigManager.java
@@ -16,6 +16,7 @@ import com.lothrazar.cyclic.block.forester.TileForester;
 import com.lothrazar.cyclic.block.harvester.TileHarvester;
 import com.lothrazar.cyclic.block.melter.TileMelter;
 import com.lothrazar.cyclic.block.miner.TileMiner;
+import com.lothrazar.cyclic.block.peatfarm.TilePeatFarm;
 import com.lothrazar.cyclic.block.solidifier.TileSolidifier;
 import com.lothrazar.cyclic.block.uncrafter.TileUncraft;
 import net.minecraftforge.common.ForgeConfigSpec;
@@ -111,7 +112,7 @@ public class ConfigManager {
     ENCHANTMENTS = CFG.comment("Disable all 11 enchantments").define(category + "enchantments", true);
     category = "energy.";
     category = "energy.fuel.";
-    PEATPOWER = CFG.comment("Power to repair one tick of durability")
+    PEATPOWER = CFG.comment("Power gained burning one of this")
         .defineInRange(category + "peat_fuel", 256, 1, 64000);
     PEATERICHPOWER = CFG.comment("Power gained burning one of this")
         .defineInRange(category + "peat_fuel_enriched", 256 * 4, 1, 64000);
@@ -127,6 +128,7 @@ public class ConfigManager {
     TileMiner.POWERCONF = CFG.comment("Power per use").defineInRange(category + "miner", 10, 0, 64000);
     TileUncraft.POWERCONF = CFG.comment("Power per use").defineInRange(category + "uncraft", 1000, 0, 64000);
     TileFluidCollect.POWERCONF = CFG.comment("Power per use").defineInRange(category + "collector_fluid", 500, 0, 64000);
+    TilePeatFarm.POWERCONF = CFG.comment("Power per use").defineInRange(category + "peat_farm", 500, 0, 64000);
     category = "peat.";
     PEATCHANCE = CFG.comment("Chance that Peat Bog converts to Peat when wet (is multiplied by the number of surrounding water blocks)")
         .defineInRange(category + "conversionChance",

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/BlockPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/BlockPeatFarm.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclic.block.peatfarm;
+
+import com.lothrazar.cyclic.base.BlockBase;
+import com.lothrazar.cyclic.block.user.ScreenUser;
+import com.lothrazar.cyclic.registry.ContainerScreenRegistry;
+import com.lothrazar.cyclic.util.UtilSound;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.ToolType;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.network.NetworkHooks;
+
+public class BlockPeatFarm extends BlockBase {
+
+    public BlockPeatFarm(Properties properties) {
+        super(properties.harvestTool(ToolType.PICKAXE).hardnessAndResistance(1.2F)
+                .notSolid());
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public void registerClient() {
+        ScreenManager.registerFactory(ContainerScreenRegistry.peat_farm, ScreenPeatFarm::new);
+    }
+
+    @Override
+    public boolean hasTileEntity(BlockState state) {
+        return true;
+    }
+
+    @Override
+    public TileEntity createTileEntity(BlockState state, IBlockReader world) {
+        return new TilePeatFarm();
+    }
+
+    @Override
+    public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult hit) {
+        if (!world.isRemote) {
+            TileEntity tankHere = world.getTileEntity(pos);
+            if (tankHere != null) {
+                IFluidHandler handler = tankHere.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, hit.getFace()).orElse(null);
+                if (handler != null
+                        && FluidUtil.interactWithFluidHandler(player, hand, handler)
+                        && handler.getFluidInTank(0) != null) {
+                    player.sendStatusMessage(new TranslationTextComponent(""
+                        + handler.getFluidInTank(0).getAmount() + "/" + handler.getTankCapacity(0)), true);
+                    if (player instanceof ServerPlayerEntity) {
+                        UtilSound.playSoundFromServer((ServerPlayerEntity) player, SoundEvents.ITEM_BUCKET_FILL);
+                    }
+                }
+                else {
+                    TileEntity tileEntity = world.getTileEntity(pos);
+                    if (tileEntity instanceof INamedContainerProvider) {
+                        NetworkHooks.openGui((ServerPlayerEntity) player, (INamedContainerProvider) tileEntity, tileEntity.getPos());
+                    }
+                    else {
+                        throw new IllegalStateException("Our named container provider is missing!");
+                    }
+                    return ActionResultType.SUCCESS;
+                }
+            }
+        }
+        if (FluidUtil.getFluidHandler(player.getHeldItem(hand)).isPresent()) {
+            return ActionResultType.SUCCESS;
+        }
+        return super.onBlockActivated(state, world, pos, player, hand, hit);
+    }
+}

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
@@ -41,7 +41,7 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 public class ContainerPeatFarm extends ContainerBase {
 
     static final int SLOTY_FLUID = 39;
-    static final int SLOTX_START = 36;
+    static final int SLOTX_START = 16;
     static final int MID_SPACING = 52;
     public static final int SLOTY = 36;
 

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclic.block.peatfarm;
+
+import com.lothrazar.cyclic.base.ContainerBase;
+import com.lothrazar.cyclic.data.Const;
+import com.lothrazar.cyclic.registry.BlockRegistry;
+import com.lothrazar.cyclic.registry.ContainerScreenRegistry;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.util.IWorldPosCallable;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.SlotItemHandler;
+import net.minecraftforge.items.wrapper.InvWrapper;
+
+public class ContainerPeatFarm extends ContainerBase {
+
+    static final int SLOTY_FLUID = 39;
+    static final int SLOTX_START = 36;
+    static final int MID_SPACING = 52;
+    public static final int SLOTY = 36;
+
+    protected TilePeatFarm tile;
+
+    public ContainerPeatFarm(int windowId, World world, BlockPos pos, PlayerInventory playerInventory, PlayerEntity player) {
+        super(ContainerScreenRegistry.peat_farm, windowId);
+        tile = (TilePeatFarm) world.getTileEntity(pos);
+        this.playerEntity = player;
+        this.playerInventory = new InvWrapper(playerInventory);
+        tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
+            this.endInv = h.getSlots();
+            int rowSize = 6;
+            for (int i = 0; i < rowSize; i++) {
+                addSlot(new SlotItemHandler(h, i, SLOTX_START + i * Const.SQ, SLOTY));
+            }
+            //for (int i = rowSize; i < 2 * rowSize; i++) {
+            //    addSlot(new SlotItemHandler(h, i, SLOTX_START + (i - rowSize) * Const.SQ, SLOTY + Const.SQ));
+            //}
+        });
+        layoutPlayerInventorySlots(8, 84);
+        this.trackAllIntFields(tile, TilePeatFarm.Fields.values().length);
+        trackEnergy(tile);
+    }
+
+    public int getEnergy() {
+        return tile.getCapability(CapabilityEnergy.ENERGY).map(IEnergyStorage::getEnergyStored).orElse(0);
+    }
+
+    @Override
+    public boolean canInteractWith(PlayerEntity playerIn) {
+        return isWithinUsableDistance(IWorldPosCallable.of(tile.getWorld(), tile.getPos()), playerEntity, BlockRegistry.peat_farm);
+    }
+}

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
@@ -1,0 +1,65 @@
+package com.lothrazar.cyclic.block.peatfarm;
+
+import com.lothrazar.cyclic.base.ScreenBase;
+import com.lothrazar.cyclic.block.collectfluid.TileFluidCollect;
+import com.lothrazar.cyclic.block.solidifier.TileSolidifier;
+import com.lothrazar.cyclic.data.Const;
+import com.lothrazar.cyclic.gui.ButtonMachineRedstone;
+import com.lothrazar.cyclic.gui.EnergyBar;
+import com.lothrazar.cyclic.gui.FluidBar;
+import com.lothrazar.cyclic.registry.TextureRegistry;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.util.text.ITextComponent;
+
+public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
+
+    private EnergyBar energy;
+    private FluidBar fluid;
+    private ButtonMachineRedstone btnRedstone;
+    private ButtonMachineRedstone btnRender;
+
+    public ScreenPeatFarm(ContainerPeatFarm screenContainer, PlayerInventory inv, ITextComponent titleIn) {
+        super(screenContainer, inv, titleIn);
+        fluid = new FluidBar(this, 8, 8, TileFluidCollect.CAPACITY);
+        energy = new EnergyBar(this, TilePeatFarm.MAX);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        fluid.guiLeft = energy.guiLeft = guiLeft;
+        fluid.guiTop = energy.guiTop = guiTop;
+        energy.visible = TileSolidifier.POWERCONF.get() > 0;
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        super.render(ms, mouseX, mouseY, partialTicks);
+        this.renderHoveredTooltip(ms, mouseX, mouseY);
+        energy.renderHoveredToolTip(ms, mouseX, mouseY, container.getEnergy());
+        fluid.renderHoveredToolTip(ms, mouseX, mouseY, container.tile.getFluid());
+    }
+
+    @Override
+    protected void drawGuiContainerForegroundLayer(MatrixStack ms, int mouseX, int mouseY) {
+        this.drawButtonTooltips(ms, mouseX, mouseY);
+        this.drawName(ms, title.getString());
+    }
+
+    @Override
+    protected void drawGuiContainerBackgroundLayer(MatrixStack ms, float partialTicks, int x, int y) {
+        this.drawBackground(ms, TextureRegistry.INVENTORY);
+        energy.draw(ms, container.getEnergy());
+        fluid.draw(ms, container.tile.getFluid());
+        int rowSize = 6;
+        int x1 = ContainerPeatFarm.SLOTX_START;
+        int y1 = ContainerPeatFarm.SLOTY;
+        for (int i = 0; i < rowSize; i++) {
+            int x2 = x1 + i * Const.SQ - 1;
+            int y2 = y1 - 1;
+            this.drawSlot(ms, x2, y2);
+        }
+    }
+}

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
@@ -17,11 +17,10 @@ public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
     private EnergyBar energy;
     private FluidBar fluid;
     private ButtonMachineRedstone btnRedstone;
-    private ButtonMachineRedstone btnRender;
 
     public ScreenPeatFarm(ContainerPeatFarm screenContainer, PlayerInventory inv, ITextComponent titleIn) {
         super(screenContainer, inv, titleIn);
-        fluid = new FluidBar(this, 8, 8, TilePeatFarm.CAPACITY);
+        fluid = new FluidBar(this, 132, 8, TilePeatFarm.CAPACITY);
         energy = new EnergyBar(this, TilePeatFarm.MAX);
     }
 
@@ -32,7 +31,7 @@ public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
         fluid.guiTop = energy.guiTop = guiTop;
         energy.visible = TileSolidifier.POWERCONF.get() > 0;
         int x, y;
-        x = guiLeft + ContainerPeatFarm.SLOTX_START;
+        x = guiLeft + 8;
         y = guiTop + 8;
         btnRedstone = addButton(new ButtonMachineRedstone(x, y, TilePeatFarm.Fields.REDSTONE.ordinal(), container.tile.getPos()));
     }

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ScreenPeatFarm.java
@@ -1,9 +1,9 @@
 package com.lothrazar.cyclic.block.peatfarm;
 
 import com.lothrazar.cyclic.base.ScreenBase;
-import com.lothrazar.cyclic.block.collectfluid.TileFluidCollect;
 import com.lothrazar.cyclic.block.solidifier.TileSolidifier;
 import com.lothrazar.cyclic.data.Const;
+import com.lothrazar.cyclic.gui.ButtonMachine;
 import com.lothrazar.cyclic.gui.ButtonMachineRedstone;
 import com.lothrazar.cyclic.gui.EnergyBar;
 import com.lothrazar.cyclic.gui.FluidBar;
@@ -21,7 +21,7 @@ public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
 
     public ScreenPeatFarm(ContainerPeatFarm screenContainer, PlayerInventory inv, ITextComponent titleIn) {
         super(screenContainer, inv, titleIn);
-        fluid = new FluidBar(this, 8, 8, TileFluidCollect.CAPACITY);
+        fluid = new FluidBar(this, 8, 8, TilePeatFarm.CAPACITY);
         energy = new EnergyBar(this, TilePeatFarm.MAX);
     }
 
@@ -31,6 +31,10 @@ public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
         fluid.guiLeft = energy.guiLeft = guiLeft;
         fluid.guiTop = energy.guiTop = guiTop;
         energy.visible = TileSolidifier.POWERCONF.get() > 0;
+        int x, y;
+        x = guiLeft + ContainerPeatFarm.SLOTX_START;
+        y = guiTop + 8;
+        btnRedstone = addButton(new ButtonMachineRedstone(x, y, TilePeatFarm.Fields.REDSTONE.ordinal(), container.tile.getPos()));
     }
 
     @Override
@@ -46,6 +50,7 @@ public class ScreenPeatFarm extends ScreenBase<ContainerPeatFarm> {
     protected void drawGuiContainerForegroundLayer(MatrixStack ms, int mouseX, int mouseY) {
         this.drawButtonTooltips(ms, mouseX, mouseY);
         this.drawName(ms, title.getString());
+        btnRedstone.onValueUpdate(container.tile);
     }
 
     @Override

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclic.block.peatfarm;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.lothrazar.cyclic.base.FluidTankBase;
+import com.lothrazar.cyclic.base.TileEntityBase;
+import com.lothrazar.cyclic.block.BlockPeatFuel;
+import com.lothrazar.cyclic.capability.CustomEnergyStorage;
+import com.lothrazar.cyclic.registry.BlockRegistry;
+import com.lothrazar.cyclic.registry.TileRegistry;
+import com.lothrazar.cyclic.util.UtilShape;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.ITickableTileEntity;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.common.ForgeConfigSpec.IntValue;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class TilePeatFarm extends TileEntityBase implements ITickableTileEntity, INamedContainerProvider {
+
+    public static IntValue POWERCONF;
+    public static final int CAPACITY = 64 * FluidAttributes.BUCKET_VOLUME;
+    static final int MAX = 64000;
+    FluidTankBase tank;
+    private final LazyOptional<FluidTankBase> tankWrapper = LazyOptional.of(() -> tank);
+    private LazyOptional<IItemHandler> inventory = LazyOptional.of(this::createHandler);
+    private LazyOptional<IEnergyStorage> energy = LazyOptional.of(this::createEnergy);
+    public static final int TIMER_FULL = 1 * 10;
+    private static final int PER_TICK = 1;
+
+    static enum Fields {
+        REDSTONE, RENDER;
+    }
+
+    @Override
+    public ITextComponent getDisplayName() {
+        return new StringTextComponent(getType().getRegistryName().getPath());
+    }
+
+
+    @Nullable
+    @Override
+    public Container createMenu(int i, PlayerInventory playerInventory, PlayerEntity playerEntity) {
+        return new ContainerPeatFarm(i, world, pos, playerInventory, playerEntity);
+    }
+
+    private void init() {
+        if (baked == null)
+            baked = BlockRegistry.peat_baked;
+        if (unbaked == null)
+            unbaked = BlockRegistry.peat_unbaked;
+        if (outer == null) {
+            outer = getShape();
+            List<BlockPos> waterShape = UtilShape.squareHorizontalHollow(this.pos, 6);
+            outer.addAll(waterShape);
+        }
+    }
+
+    @Override
+    public void tick() {
+        this.init();
+        if (this.requiresRedstone() && !this.isPowered()) {
+            setLitProperty(false);
+            blockPointer = 0;
+            return;
+        }
+        setLitProperty(true);
+        IEnergyStorage cap = this.energy.orElse(null);
+        if (cap == null) {
+            return;
+        }
+
+        if (this.timer > 0) {
+            this.timer--;
+            return;
+        }
+        for (int i = 0; i < PER_TICK; i++) {
+            if (blockPointer < outer.size()) {
+                BlockPos target = outer.get(blockPointer);
+                boolean placeWater = (target.getX() - pos.getX()) % 3 == 0
+                        && (target.getZ() - pos.getZ()) % 3 == 0;
+                if (placeWater)
+                    tryPlaceWater(target);
+                else
+                    tryPlacePeat(target);
+                blockPointer++;
+            }
+            else
+                blockPointer = 0;
+        }
+        this.timer = TIMER_FULL;
+    }
+
+    @Override
+    public void setField(int field, int value) {
+        switch (TilePeatFarm.Fields.values()[field]) {
+            case REDSTONE:
+                this.setNeedsRedstone(value);
+                break;
+            case RENDER:
+                this.render = value % 2;
+                break;
+        }
+    }
+
+    private int needsRedstone = 1;
+    private int blockPointer = 0;
+
+    public TilePeatFarm() {
+        super(TileRegistry.peat_farm);
+        tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+    }
+
+    Block baked = null;
+    Block unbaked = null;
+    List<BlockPos> outer = null;
+
+
+
+    public Predicate<FluidStack> isFluidValid() {
+        return p -> true;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int index, ItemStack stack) {
+        return Block.getBlockFromItem(stack.getItem()) == unbaked;
+    }
+
+    private List<BlockPos> getShape() {
+        List<BlockPos> outer = UtilShape.squareHorizontalHollow(this.pos, 7);
+        outer.addAll(UtilShape.squareHorizontalHollow(this.pos, 5));
+        return outer;
+    }
+
+    public FluidStack getFluid() {
+        return tank == null ? FluidStack.EMPTY : tank.getFluid();
+    }
+
+    public float getCapacity() {
+        return CAPACITY;
+    }
+
+    private void tryPlacePeat(BlockPos target) {
+        IItemHandler inventory = this.inventory.orElse(null);
+        for (int i = 0; i < inventory.getSlots(); i++) {
+            ItemStack itemStack = inventory.getStackInSlot(i);
+            BlockState state = Block.getBlockFromItem(itemStack.getItem()).getDefaultState();
+            if (itemStack.getCount() == 0)
+                continue;
+            if (world.getBlockState(target).getBlock() instanceof BlockPeatFuel) {
+                world.destroyBlock(target, true);
+
+            }
+            if ((world.isAirBlock(target)
+                    || world.getFluidState(target).getFluid() == Fluids.WATER
+                    || world.getFluidState(target).getFluid() == Fluids.FLOWING_WATER)
+                    && world.setBlockState(target, state))
+                itemStack.shrink(1);
+        }
+    }
+
+    private void tryPlaceWater(BlockPos target) {
+        if (world.getBlockState(target).isReplaceable(Fluids.WATER)
+                && world.getBlockState(target).getBlock() != Blocks.WATER
+                && tank.getFluidAmount() > FluidAttributes.BUCKET_VOLUME
+                && tank.drain(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE) != null) {
+            world.setBlockState(target, Blocks.WATER.getDefaultState());
+        }
+    }
+
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, Direction side) {
+        if (cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return inventory.cast();
+        }
+        if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            return tankWrapper.cast();
+        }
+        if (cap == CapabilityEnergy.ENERGY) {
+            return energy.cast();
+        }
+        return super.getCapability(cap, side);
+    }
+
+    private IEnergyStorage createEnergy() {
+        return new CustomEnergyStorage(MAX, MAX);
+    }
+
+    private IItemHandler createHandler() {
+        return new ItemStackHandler(6) {
+
+            @Override
+            public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+                return Block.getBlockFromItem(stack.getItem()) == BlockRegistry.peat_unbaked;
+            }
+        };
+    }
+
+    @Override
+    public void read(BlockState bs, CompoundNBT tag) {
+        tank.readFromNBT(tag.getCompound("fluid"));
+        energy.ifPresent(h -> ((INBTSerializable<CompoundNBT>) h).deserializeNBT(tag.getCompound("energy")));
+        inventory.ifPresent(h -> ((INBTSerializable<CompoundNBT>) h).deserializeNBT(tag.getCompound("inv")));
+        super.read(bs, tag);
+    }
+
+    @Override
+    public CompoundNBT write(CompoundNBT tag) {
+        CompoundNBT fluid = new CompoundNBT();
+        tank.writeToNBT(fluid);
+        tag.put("fluid", fluid);
+        energy.ifPresent(h -> {
+            CompoundNBT compound = ((INBTSerializable<CompoundNBT>) h).serializeNBT();
+            tag.put("energy", compound);
+        });
+        inventory.ifPresent(h -> {
+            CompoundNBT compound = ((INBTSerializable<CompoundNBT>) h).serializeNBT();
+            tag.put("inv", compound);
+        });
+        return super.write(tag);
+    }
+}

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 import com.lothrazar.cyclic.base.FluidTankBase;
 import com.lothrazar.cyclic.base.TileEntityBase;
 import com.lothrazar.cyclic.block.BlockPeatFuel;
+import com.lothrazar.cyclic.block.harvester.TileHarvester;
 import com.lothrazar.cyclic.capability.CustomEnergyStorage;
 import com.lothrazar.cyclic.registry.BlockRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
@@ -152,6 +153,17 @@ public class TilePeatFarm extends TileEntityBase implements ITickableTileEntity,
         }
     }
 
+    @Override
+    public int getField(int id) {
+        switch (TilePeatFarm.Fields.values()[id]) {
+            case REDSTONE:
+                return this.needsRedstone;
+            case RENDER:
+                return render;
+        }
+        return 0;
+    }
+
     private int needsRedstone = 1;
     private int blockPointer = 0;
 
@@ -211,7 +223,7 @@ public class TilePeatFarm extends TileEntityBase implements ITickableTileEntity,
     private void tryPlaceWater(BlockPos target) {
         if (world.getBlockState(target).isReplaceable(Fluids.WATER)
                 && world.getBlockState(target).getBlock() != Blocks.WATER
-                && tank.getFluidAmount() > FluidAttributes.BUCKET_VOLUME
+                && tank.getFluidAmount() >= FluidAttributes.BUCKET_VOLUME
                 && tank.drain(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE) != null) {
             world.setBlockState(target, Blocks.WATER.getDefaultState());
         }

--- a/src/main/java/com/lothrazar/cyclic/registry/BlockRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/BlockRegistry.java
@@ -40,6 +40,7 @@ import com.lothrazar.cyclic.block.generatorpeat.BlockPeatGenerator;
 import com.lothrazar.cyclic.block.harvester.BlockHarvester;
 import com.lothrazar.cyclic.block.melter.BlockMelter;
 import com.lothrazar.cyclic.block.miner.BlockMiner;
+import com.lothrazar.cyclic.block.peatfarm.BlockPeatFarm;
 import com.lothrazar.cyclic.block.placer.BlockPlacer;
 import com.lothrazar.cyclic.block.placerfluid.BlockPlacerFluid;
 import com.lothrazar.cyclic.block.scaffolding.BlockScaffolding;
@@ -97,6 +98,8 @@ public class BlockRegistry {
   public static BlockPeat peat_unbaked;
   @ObjectHolder(ModCyclic.MODID + ":peat_baked")
   public static BlockPeatFuel peat_baked;
+  @ObjectHolder(ModCyclic.MODID + ":peat_farm")
+  public static BlockPeatFarm peat_farm;
   @ObjectHolder(ModCyclic.MODID + ":breaker")
   public static Block breaker;
   @ObjectHolder(ModCyclic.MODID + ":fan")
@@ -205,6 +208,7 @@ public class BlockRegistry {
     r.register(new BlockPeatGenerator(Block.Properties.create(Material.ROCK)).setRegistryName("peat_generator"));
     r.register(new BlockPeat(Block.Properties.create(Material.EARTH).sound(SoundType.GROUND)).setRegistryName("peat_unbaked"));
     r.register(new BlockPeatFuel(Block.Properties.create(Material.EARTH).sound(SoundType.GROUND)).setRegistryName("peat_baked"));
+    r.register(new BlockPeatFarm(Block.Properties.create(Material.ROCK)).setRegistryName("peat_farm"));
     r.register(new BlockTerraPreta(Block.Properties.create(Material.EARTH)).setRegistryName("terra_preta"));
     r.register(new BlockSolidifier(Block.Properties.create(Material.ROCK)).setRegistryName("solidifier"));
     r.register(new BlockMelter(Block.Properties.create(Material.ROCK)).setRegistryName("melter"));

--- a/src/main/java/com/lothrazar/cyclic/registry/ContainerScreenRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/ContainerScreenRegistry.java
@@ -21,6 +21,7 @@ import com.lothrazar.cyclic.block.generatorpeat.ContainerGenerator;
 import com.lothrazar.cyclic.block.harvester.ContainerHarvester;
 import com.lothrazar.cyclic.block.melter.ContainerMelter;
 import com.lothrazar.cyclic.block.miner.ContainerMiner;
+import com.lothrazar.cyclic.block.peatfarm.ContainerPeatFarm;
 import com.lothrazar.cyclic.block.placer.ContainerPlacer;
 import com.lothrazar.cyclic.block.placerfluid.ContainerPlacerFluid;
 import com.lothrazar.cyclic.block.screen.ContainerScreentext;
@@ -49,6 +50,9 @@ public class ContainerScreenRegistry {
     r.register(IForgeContainerType.create((windowId, inv, data) -> {
       return new ContainerGenerator(windowId, ModCyclic.proxy.getClientWorld(), data.readBlockPos(), inv, ModCyclic.proxy.getClientPlayer());
     }).setRegistryName("peat_generator"));
+    r.register(IForgeContainerType.create((windowId, inv, data) -> {
+      return new ContainerPeatFarm(windowId, ModCyclic.proxy.getClientWorld(), data.readBlockPos(), inv, ModCyclic.proxy.getClientPlayer());
+    }).setRegistryName("peat_farm"));
     r.register(IForgeContainerType.create((windowId, inv, data) -> {
       return new ContainerBattery(windowId, ModCyclic.proxy.getClientWorld(), data.readBlockPos(), inv, ModCyclic.proxy.getClientPlayer());
     }).setRegistryName("battery"));
@@ -149,6 +153,8 @@ public class ContainerScreenRegistry {
   public static ContainerType<ContainerItemCollector> collectortileContainer;
   @ObjectHolder(ModCyclic.MODID + ":peat_generator")
   public static ContainerType<ContainerGenerator> generatorCont;
+  @ObjectHolder(ModCyclic.MODID + ":peat_farm")
+  public static ContainerType<ContainerPeatFarm> peat_farm;
   @ObjectHolder(ModCyclic.MODID + ":harvester")
   public static ContainerType<ContainerHarvester> harvester;
   @ObjectHolder(ModCyclic.MODID + ":experience_pylon")

--- a/src/main/java/com/lothrazar/cyclic/registry/ItemRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/ItemRegistry.java
@@ -126,6 +126,7 @@ public class ItemRegistry {
     r.register(new BlockItem(BlockRegistry.peat_unbaked, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("peat_unbaked"));
     r.register(new BlockItem(BlockRegistry.peat_baked, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("peat_baked"));
     r.register(new BlockItem(BlockRegistry.solidifier, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("solidifier"));
+    r.register(new BlockItem(BlockRegistry.peat_farm, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("peat_farm"));
     r.register(new BlockItem(BlockRegistry.melter, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("melter"));
     //    r.register(new BlockItem(BlockRegistry.crafter, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("crafter"));
     r.register(new BlockItem(BlockRegistry.placer, new Item.Properties().group(MaterialRegistry.blockgrp)).setRegistryName("placer"));

--- a/src/main/java/com/lothrazar/cyclic/registry/TileRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/TileRegistry.java
@@ -28,6 +28,7 @@ import com.lothrazar.cyclic.block.generatorpeat.TilePeatGenerator;
 import com.lothrazar.cyclic.block.harvester.TileHarvester;
 import com.lothrazar.cyclic.block.melter.TileMelter;
 import com.lothrazar.cyclic.block.miner.TileMiner;
+import com.lothrazar.cyclic.block.peatfarm.TilePeatFarm;
 import com.lothrazar.cyclic.block.placer.TilePlacer;
 import com.lothrazar.cyclic.block.placerfluid.TilePlacerFluid;
 import com.lothrazar.cyclic.block.screen.TileScreentext;
@@ -87,6 +88,7 @@ public class TileRegistry {
     r.register(TileEntityType.Builder.create(TileExpPylon::new, BlockRegistry.experience_pylon).build(null).setRegistryName("experience_pylon"));
     r.register(TileEntityType.Builder.create(TileTrash::new, BlockRegistry.trash).build(null).setRegistryName("trash"));
     r.register(TileEntityType.Builder.create(TilePeatGenerator::new, BlockRegistry.peat_generator).build(null).setRegistryName("peat_generator"));
+    r.register(TileEntityType.Builder.create(TilePeatFarm::new, BlockRegistry.peat_farm).build(null).setRegistryName("peat_farm"));
     r.register(TileEntityType.Builder.create(TileBattery::new, BlockRegistry.battery).build(null).setRegistryName("battery"));
     r.register(TileEntityType.Builder.create(TileCableEnergy::new, BlockRegistry.energy_pipe).build(null).setRegistryName("energy_pipe"));
     r.register(TileEntityType.Builder.create(TileCableItem::new, BlockRegistry.item_pipe).build(null).setRegistryName("item_pipe"));
@@ -135,6 +137,8 @@ public class TileRegistry {
   public static TileEntityType<TileTrash> trashtile;
   @ObjectHolder(ModCyclic.MODID + ":peat_generator")
   public static TileEntityType<TilePeatGenerator> peat_generator;
+  @ObjectHolder(ModCyclic.MODID + ":peat_farm")
+  public static TileEntityType<TilePeatGenerator> peat_farm;
   @ObjectHolder(ModCyclic.MODID + ":harvester")
   public static TileEntityType<TileHarvester> harvesterTile;
   @ObjectHolder(ModCyclic.MODID + ":breaker")

--- a/src/main/resources/assets/cyclic/blockstates/peat_farm.json
+++ b/src/main/resources/assets/cyclic/blockstates/peat_farm.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "cyclic:block/peat_farm" }
+  }
+}

--- a/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/src/main/resources/assets/cyclic/lang/en_us.json
@@ -1014,6 +1014,10 @@
     "block.cyclic.peat_generator.tooltip": "Generate power",
     "block.cyclic.peat_generator.guide": "Burn peat to create Energy.  Create Peat Fuel using Biomass, Peat Bog, and Carbon Catalyst.",
 
+    "block.cyclic.peat_farm": "Peat Farm",
+    "block.cyclic.peat_farm.tooltip": "Harvest saturated peat deposits",
+    "block.cyclic.peat_farm.guide": "Places dry peat bog and harvests it when it becomes saturated.",
+
     "block.cyclic.peat_farm": "Peat Farmer",
     "block.cyclic.peat_farm.tooltip": "Places and harvests a Peat Bog",
     "block.cyclic.peat_farm.guide": "Places and harvests a Peat Bog.  Requires energy and water.",

--- a/src/main/resources/assets/cyclic/models/block/peat_farm.json
+++ b/src/main/resources/assets/cyclic/models/block/peat_farm.json
@@ -1,0 +1,9 @@
+{
+  "parent": "cyclic:parent/machine_simple",
+  "textures": {
+    "side": "cyclic:blocks/machine/back",
+    "base": "cyclic:blocks/peat_baked",
+    "inner": "cyclic:blocks/machine/white",
+    "particle": "cyclic:blocks/machine/peat"
+  }
+}

--- a/src/main/resources/assets/cyclic/models/item/peat_farm.json
+++ b/src/main/resources/assets/cyclic/models/item/peat_farm.json
@@ -1,0 +1,3 @@
+{
+  "parent": "cyclic:block/peat_generator"
+}

--- a/src/main/resources/data/cyclic/recipes/peat_farm.json
+++ b/src/main/resources/data/cyclic/recipes/peat_farm.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "ipi",
+    "fof",
+    "ipi"
+  ],
+  "key": {
+    "i": {
+      "item": "minecraft:gold_ingot"
+    },
+    "p": {
+      "item": "minecraft:dispenser"
+    },
+    "f": {
+      "item": "cyclic:peat_generator"
+    },
+    "o": {
+      "item": "minecraft:observer"
+    }
+  },
+  "result": {
+    "item": "cyclic:peat_farm",
+    "count": 1
+  }
+}


### PR DESCRIPTION
More or less a direct port of the Peat Farm from 1.12.

For @Lothrazar to fix:

- Redstone button doesn't update in GUI (similar problem observed on other machines, but Harvester displays correct behavior)
- Fluid tank only updates visually on world/chunk loading
- Has the same model as the Peat Bog currently, as a placeholder