### PR TITLE
[1.16] Port Auto Smelt from 1.12

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/enchant/EnchantAutoSmelt.java
+++ b/src/main/java/com/lothrazar/cyclic/enchant/EnchantAutoSmelt.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2014-2018 Sam Bassett (aka Lothrazar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.lothrazar.cyclic.enchant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gson.JsonObject;
+import com.lothrazar.cyclic.base.EnchantBase;
+import net.minecraft.enchantment.Enchantment;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.EnchantmentType;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.item.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.crafting.FurnaceRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootParameters;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
+import net.minecraftforge.common.loot.LootModifier;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+import javax.annotation.Nonnull;
+
+
+public class EnchantAutoSmelt extends EnchantBase {
+
+    public EnchantAutoSmelt(Rarity rarityIn, EnchantmentType typeIn, EquipmentSlotType... slots) {
+        super(rarityIn, typeIn, slots);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public int getMaxLevel() {
+        return 1;
+    }
+
+    @Override
+    public boolean canApplyTogether(Enchantment ench) {
+        return ench != Enchantments.SILK_TOUCH && ench != Enchantments.FORTUNE && super.canApplyTogether(ench);
+    }
+
+    private static class EnchantAutoSmeltModifier extends LootModifier {
+        public EnchantAutoSmeltModifier(ILootCondition[] conditionsIn) {
+            super(conditionsIn);
+        }
+
+        @Nonnull
+        @Override
+        public List<ItemStack> doApply(List<ItemStack> originalLoot, LootContext context) {
+            List<ItemStack> newLoot = new ArrayList<>();
+            originalLoot.add(new ItemStack(Items.GOLD_ORE, 5));
+            originalLoot.add(new ItemStack(Items.DIAMOND, 5));
+            originalLoot.forEach((stack) -> {
+                Optional<FurnaceRecipe> optional = context.getWorld().getRecipeManager().getRecipe(IRecipeType.SMELTING, new Inventory(stack), context.getWorld());
+                if (optional.isPresent()) {
+                    ItemStack smeltedItemStack = optional.get().getRecipeOutput();
+                    if (!smeltedItemStack.isEmpty()) {
+                        smeltedItemStack = ItemHandlerHelper.copyStackWithSize(smeltedItemStack, stack.getCount() * smeltedItemStack.getCount());
+                        newLoot.add(smeltedItemStack);
+                    }
+                    else {
+                        newLoot.add(stack);
+                    }
+                }
+                else {
+                    newLoot.add(stack);
+                }
+            });
+            return newLoot;
+        }
+    }
+    public static class Serializer extends GlobalLootModifierSerializer<EnchantAutoSmeltModifier> {
+        @Override
+        public EnchantAutoSmeltModifier read(ResourceLocation name, JsonObject json, ILootCondition[] conditionsIn) {
+            return new EnchantAutoSmeltModifier(conditionsIn);
+        }
+
+        @Override
+        public JsonObject write(EnchantAutoSmeltModifier instance) {
+            return null; //not sure what to do with this
+        }
+    }
+}

--- a/src/main/java/com/lothrazar/cyclic/registry/EnchantRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/EnchantRegistry.java
@@ -1,19 +1,7 @@
 package com.lothrazar.cyclic.registry;
 
 import com.lothrazar.cyclic.ConfigManager;
-import com.lothrazar.cyclic.enchant.EnchantBeheading;
-import com.lothrazar.cyclic.enchant.EnchantExcavation;
-import com.lothrazar.cyclic.enchant.EnchantGrowth;
-import com.lothrazar.cyclic.enchant.EnchantLaunch;
-import com.lothrazar.cyclic.enchant.EnchantLifeLeech;
-import com.lothrazar.cyclic.enchant.EnchantMagnet;
-import com.lothrazar.cyclic.enchant.EnchantMultishot;
-import com.lothrazar.cyclic.enchant.EnchantQuickdraw;
-import com.lothrazar.cyclic.enchant.EnchantReach;
-import com.lothrazar.cyclic.enchant.EnchantStep;
-import com.lothrazar.cyclic.enchant.EnchantTraveller;
-import com.lothrazar.cyclic.enchant.EnchantVenom;
-import com.lothrazar.cyclic.enchant.EnchantXp;
+import com.lothrazar.cyclic.enchant.*;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.inventory.EquipmentSlotType;
@@ -42,6 +30,7 @@ public class EnchantRegistry {
       r.register(new EnchantStep(Enchantment.Rarity.RARE, EnchantmentType.ARMOR_LEGS, EquipmentSlotType.LEGS).setRegistryName("step"));
       r.register(new EnchantTraveller(Enchantment.Rarity.VERY_RARE, EnchantmentType.ARMOR_LEGS, EquipmentSlotType.LEGS).setRegistryName("traveler"));
       r.register(new EnchantVenom(Enchantment.Rarity.UNCOMMON, EnchantmentType.WEAPON, EquipmentSlotType.MAINHAND).setRegistryName("venom"));
+      r.register(new EnchantAutoSmelt(Enchantment.Rarity.RARE, EnchantmentType.DIGGER, EquipmentSlotType.MAINHAND).setRegistryName("auto_smelt"));
     }
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/registry/LootModifierRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/LootModifierRegistry.java
@@ -1,0 +1,23 @@
+package com.lothrazar.cyclic.registry;
+
+import com.lothrazar.cyclic.ConfigManager;
+import com.lothrazar.cyclic.ModCyclic;
+import com.lothrazar.cyclic.enchant.EnchantAutoSmelt;
+import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import javax.annotation.Nonnull;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class LootModifierRegistry {
+
+    @SubscribeEvent
+    public static void registerModifierSerializers(@Nonnull final RegistryEvent.Register<GlobalLootModifierSerializer<?>> event) {
+        if (ConfigManager.ENCHANTMENTS.get()) {
+            event.getRegistry().register(new EnchantAutoSmelt.Serializer().setRegistryName(ModCyclic.MODID + ":auto_smelt"));
+        }
+    }
+
+}

--- a/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/src/main/resources/assets/cyclic/lang/en_us.json
@@ -197,6 +197,8 @@
     "enchantment.cyclic.traveler.desc": "Protects against exploration hazards (elytra, ender pearls, cacti, bees, fall resistance)",
     "enchantment.cyclic.venom": "Venom",
     "enchantment.cyclic.venom.desc": "Inflicts the poison status effect on the target",
+    "enchantment.cyclic.auto_smelt": "Auto Smelt",
+    "enchantment.cyclic.auto_smelt.desc": "Smelts whatever you harvest with this tool.",
     "entity.Villager.druid": "Druid",
     "entity.Villager.sage": "Sage",
     "fluid.cyclic.biomass": "Biomass",

--- a/src/main/resources/data/cyclic/loot_modifiers/auto_smelt.json
+++ b/src/main/resources/data/cyclic/loot_modifiers/auto_smelt.json
@@ -1,0 +1,18 @@
+{
+  "type": "cyclic:auto_smelt",
+  "conditions": [
+    {
+      "condition": "minecraft:match_tool",
+      "predicate": {
+        "enchantments": [
+          {
+            "enchantment": "cyclic:auto_smelt",
+            "levels": {
+              "min": 1
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "entries": [
+    "cyclic:auto_smelt"
+  ]
+}


### PR DESCRIPTION
Implement new global loot modifier introduced in 1.15.x for properly handling the smelting
Add global_loot_modifiers.json where you can register future loot modifiers
Add auto_smelt.json, which is the data-driven "entry point" to modifying loot (each future loot modifier will need its own file here)