### PR TITLE
[1.16] XP Enchant Fix and Changes

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/enchant/EnchantXp.java
+++ b/src/main/java/com/lothrazar/cyclic/enchant/EnchantXp.java
@@ -29,7 +29,7 @@ public class EnchantXp extends EnchantBase {
     if (level <= 0) {
       return;
     }
-    event.setExpToDrop(event.getExpToDrop() + event.getPlayer().world.rand.nextInt(getMaxLevel()) * (level + 1));
+    event.setExpToDrop(event.getExpToDrop() + getRandomExpAmount(level, event.getPlayer().world));
   }
 
   @SubscribeEvent


### PR DESCRIPTION
Fix #1548 where XP Enchantment triggers when enchanted item is held in the offhand and blocks are broken with the mainhand.

Change XP Enchantment to drop orbs when blocks are broken and entities are killed, instead of adding directly to the player's experience.