### PR TITLE
[1.16] Fix Boomerang carrying the player who threw it

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/item/boomerang/BoomerangEntity.java
+++ b/src/main/java/com/lothrazar/cyclic/item/boomerang/BoomerangEntity.java
@@ -262,12 +262,12 @@ public class BoomerangEntity extends ProjectileItemEntity {
     if (owner == entityHit) {
       //player catch it on return 
       dropAsItem();
-      //      ModCyclic.LOGGER.info("Drop by catching ");
       return;
     }
     switch (this.boomerangType) {
       case CARRY:
-        entityHit.startRiding(this);
+        if (!entityHit.world.isRemote)
+          entityHit.startRiding(this);
       break;
       case DAMAGE:
         if (entityHit instanceof LivingEntity) {


### PR DESCRIPTION
Fix #1555 Boomerang (boomerang_carry) picks up the player that threw it due to missing world.isRemote check.