### PR TITLE
[1.16] Fix missing world.isRemote check causing client desync of applied potion effect on Gloom

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/enchant/EnchantCurse.java
+++ b/src/main/java/com/lothrazar/cyclic/enchant/EnchantCurse.java
@@ -39,7 +39,7 @@ public class EnchantCurse extends EnchantBase {
 
   @Override
   public void onUserHurt(LivingEntity user, Entity attacker, int level) {
-    if (!(attacker instanceof LivingEntity))
+    if (user.world.isRemote || !(attacker instanceof LivingEntity))
       return;
     //only allow activation once
     int totalLevels = getCurrentArmorLevelSlot(user, EquipmentSlotType.HEAD)


### PR DESCRIPTION
Fixes #1591 