### PR TITLE
[1.16] Fix Monster Ball not waking up sleeping entity

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/item/magicnet/EntityMagicNetEmpty.java
+++ b/src/main/java/com/lothrazar/cyclic/item/magicnet/EntityMagicNetEmpty.java
@@ -52,6 +52,10 @@ public class EntityMagicNetEmpty extends ProjectileItemEntity {
       if (target instanceof PlayerEntity || !target.isAlive()) {
         return;
       }
+      //Wake up the mob in case they're sleeping in a bed see Issue #1599
+      if (target instanceof LivingEntity) {
+        ((LivingEntity)target).wakeUp();
+      }
       CompoundNBT compound = new CompoundNBT();
       target.writeUnlessPassenger(compound);
       String id = EntityType.getKey(target.getType()).toString();


### PR DESCRIPTION
Fix Issue #1599 capturing a sleeping entity causes them to try to return to their bed when released from Monster Ball.