### PR TITLE
Convert InvWrapper to plain-ol PlayerInventory in all Containers so I…

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/base/ContainerBase.java
+++ b/src/main/java/com/lothrazar/cyclic/base/ContainerBase.java
@@ -1,6 +1,7 @@
 package com.lothrazar.cyclic.base;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.inventory.container.Slot;
@@ -8,13 +9,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IntReferenceHolder;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.SlotItemHandler;
 
 public abstract class ContainerBase extends Container {
 
   protected PlayerEntity playerEntity;
-  protected IItemHandler playerInventory;
+  protected PlayerInventory playerInventory;
   protected int startInv = 0;
   protected int endInv = 17;//must be set by extending class
   public static final int PLAYERSIZE = 4 * 9;//36
@@ -113,16 +112,16 @@ public abstract class ContainerBase extends Container {
     }
   }
 
-  private int addSlotRange(IItemHandler handler, int index, int x, int y, int amount, int dx) {
+  private int addSlotRange(PlayerInventory handler, int index, int x, int y, int amount, int dx) {
     for (int i = 0; i < amount; i++) {
-      addSlot(new SlotItemHandler(handler, index, x, y));
+      addSlot(new Slot(handler, index, x, y));
       x += dx;
       index++;
     }
     return index;
   }
 
-  private int addSlotBox(IItemHandler handler, int index, int x, int y, int horAmount, int dx, int verAmount, int dy) {
+  private int addSlotBox(PlayerInventory handler, int index, int x, int y, int horAmount, int dx, int verAmount, int dy) {
     for (int j = 0; j < verAmount; j++) {
       index = addSlotRange(handler, index, x, y, horAmount, dx);
       y += dy;

--- a/src/main/java/com/lothrazar/cyclic/block/anvil/ContainerAnvil.java
+++ b/src/main/java/com/lothrazar/cyclic/block/anvil/ContainerAnvil.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerAnvil extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerAnvil extends ContainerBase {
     super(ContainerScreenRegistry.anvil, windowId);
     tile = (TileAnvilAuto) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 55, 35));

--- a/src/main/java/com/lothrazar/cyclic/block/anvilmagma/ContainerAnvilMagma.java
+++ b/src/main/java/com/lothrazar/cyclic/block/anvilmagma/ContainerAnvilMagma.java
@@ -12,7 +12,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerAnvilMagma extends ContainerBase {
 
@@ -22,7 +21,7 @@ public class ContainerAnvilMagma extends ContainerBase {
     super(ContainerScreenRegistry.anvil_magma, windowId);
     tile = (TileAnvilMagma) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 55, 35));

--- a/src/main/java/com/lothrazar/cyclic/block/battery/ContainerBattery.java
+++ b/src/main/java/com/lothrazar/cyclic/block/battery/ContainerBattery.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerBattery extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerBattery extends ContainerBase {
     super(ContainerScreenRegistry.batteryCont, windowId);
     tile = (TileBattery) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
     trackEnergy(tile);
     this.trackAllIntFields(tile, TileBattery.Fields.values().length);

--- a/src/main/java/com/lothrazar/cyclic/block/beaconpotion/ContainerPotion.java
+++ b/src/main/java/com/lothrazar/cyclic/block/beaconpotion/ContainerPotion.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerPotion extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerPotion extends ContainerBase {
     super(ContainerScreenRegistry.beacon, windowId);
     tile = (TilePotion) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 9, 35));

--- a/src/main/java/com/lothrazar/cyclic/block/breaker/ContainerBreaker.java
+++ b/src/main/java/com/lothrazar/cyclic/block/breaker/ContainerBreaker.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerBreaker extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerBreaker extends ContainerBase {
     super(ContainerScreenRegistry.breaker, windowId);
     tile = (TileBreaker) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
     this.trackIntField(tile, TileBreaker.Fields.REDSTONE.ordinal());
   }

--- a/src/main/java/com/lothrazar/cyclic/block/clock/ContainerClock.java
+++ b/src/main/java/com/lothrazar/cyclic/block/clock/ContainerClock.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerClock extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerClock extends ContainerBase {
     super(ContainerScreenRegistry.clock, windowId);
     tile = (TileRedstoneClock) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileRedstoneClock.Fields.values().length);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/collectfluid/ContainerFluidCollect.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectfluid/ContainerFluidCollect.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerFluidCollect extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerFluidCollect extends ContainerBase {
     super(ContainerScreenRegistry.collector_fluid, windowId);
     tile = (TileFluidCollect) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 10, 51));

--- a/src/main/java/com/lothrazar/cyclic/block/collectitem/ContainerItemCollector.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectitem/ContainerItemCollector.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerItemCollector extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerItemCollector extends ContainerBase {
     super(ContainerScreenRegistry.collector, windowId);
     tile = (TileItemCollector) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       int numRows = 2;

--- a/src/main/java/com/lothrazar/cyclic/block/crafter/ContainerCrafter.java
+++ b/src/main/java/com/lothrazar/cyclic/block/crafter/ContainerCrafter.java
@@ -37,7 +37,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerCrafter extends ContainerBase {
 
@@ -74,7 +73,7 @@ public class ContainerCrafter extends ContainerBase {
     super(ContainerScreenRegistry.crafter, windowId);
     tile = (TileCrafter) clientWorld.getTileEntity(pos);
     this.playerEntity = clientPlayer;
-    this.playerInventory = new InvWrapper(inv);
+    this.playerInventory = inv;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, TileCrafter.ItemHandlers.INPUT).ifPresent(h -> {
       int index = 0;
       //add input

--- a/src/main/java/com/lothrazar/cyclic/block/crate/ContainerCrate.java
+++ b/src/main/java/com/lothrazar/cyclic/block/crate/ContainerCrate.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerCrate extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerCrate extends ContainerBase {
     super(ContainerScreenRegistry.crate, windowId);
     tile = (TileCrate) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       for (int j = 0; j < 9; ++j) {

--- a/src/main/java/com/lothrazar/cyclic/block/detectorentity/ContainerDetector.java
+++ b/src/main/java/com/lothrazar/cyclic/block/detectorentity/ContainerDetector.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerDetector extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerDetector extends ContainerBase {
     super(ContainerScreenRegistry.detector_entity, windowId);
     tile = (TileDetector) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     //    layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileDetector.Fields.values().length);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/detectoritem/ContainerDetectorItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/detectoritem/ContainerDetectorItem.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerDetectorItem extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerDetectorItem extends ContainerBase {
     super(ContainerScreenRegistry.detector_item, windowId);
     tile = (TileDetectorItem) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     //    layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileDetectorItem.Fields.values().length);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/disenchant/ContainerDisenchant.java
+++ b/src/main/java/com/lothrazar/cyclic/block/disenchant/ContainerDisenchant.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerDisenchant extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerDisenchant extends ContainerBase {
     super(ContainerScreenRegistry.disenchanter, windowId);
     tile = (TileDisenchant) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 24, 40));

--- a/src/main/java/com/lothrazar/cyclic/block/dropper/ContainerDropper.java
+++ b/src/main/java/com/lothrazar/cyclic/block/dropper/ContainerDropper.java
@@ -12,7 +12,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerDropper extends ContainerBase {
 
@@ -22,7 +21,7 @@ public class ContainerDropper extends ContainerBase {
     super(ContainerScreenRegistry.dropper, windowId);
     tile = (TileDropper) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 10, 51));

--- a/src/main/java/com/lothrazar/cyclic/block/expcollect/ContainerExpPylon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/expcollect/ContainerExpPylon.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerExpPylon extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerExpPylon extends ContainerBase {
     super(ContainerScreenRegistry.experience_pylon, windowId);
     tile = (TileExpPylon) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
   }
 

--- a/src/main/java/com/lothrazar/cyclic/block/fan/ContainerFan.java
+++ b/src/main/java/com/lothrazar/cyclic/block/fan/ContainerFan.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerFan extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerFan extends ContainerBase {
     super(ContainerScreenRegistry.fan, windowId);
     tile = (TileFan) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileFan.Fields.values().length);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/forester/ContainerForester.java
+++ b/src/main/java/com/lothrazar/cyclic/block/forester/ContainerForester.java
@@ -12,7 +12,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerForester extends ContainerBase {
 
@@ -22,7 +21,7 @@ public class ContainerForester extends ContainerBase {
     super(ContainerScreenRegistry.forester, windowId);
     tile = (TileForester) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 55, 35));

--- a/src/main/java/com/lothrazar/cyclic/block/generatorpeat/ContainerGenerator.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatorpeat/ContainerGenerator.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerGenerator extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerGenerator extends ContainerBase {
     super(ContainerScreenRegistry.generatorCont, windowId);
     tile = (TilePeatGenerator) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 80, 29));

--- a/src/main/java/com/lothrazar/cyclic/block/harvester/ContainerHarvester.java
+++ b/src/main/java/com/lothrazar/cyclic/block/harvester/ContainerHarvester.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerHarvester extends ContainerBase {
 
@@ -19,7 +18,7 @@ public class ContainerHarvester extends ContainerBase {
     super(ContainerScreenRegistry.harvester, windowId);
     tile = (TileHarvester) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileHarvester.Fields.values().length);
     trackEnergy(tile);

--- a/src/main/java/com/lothrazar/cyclic/block/melter/ContainerMelter.java
+++ b/src/main/java/com/lothrazar/cyclic/block/melter/ContainerMelter.java
@@ -12,7 +12,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerMelter extends ContainerBase {
 
@@ -22,7 +21,7 @@ public class ContainerMelter extends ContainerBase {
     super(ContainerScreenRegistry.melter, windowId);
     tile = (TileMelter) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 17, 31));

--- a/src/main/java/com/lothrazar/cyclic/block/miner/ContainerMiner.java
+++ b/src/main/java/com/lothrazar/cyclic/block/miner/ContainerMiner.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerMiner extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerMiner extends ContainerBase {
     super(ContainerScreenRegistry.miner, windowId);
     tile = (TileMiner) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 10, 51));

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/ContainerPeatFarm.java
@@ -36,7 +36,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerPeatFarm extends ContainerBase {
 
@@ -50,7 +49,7 @@ public class ContainerPeatFarm extends ContainerBase {
     super(ContainerScreenRegistry.peat_farm, windowId);
     tile = (TilePeatFarm) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       int rowSize = 6;

--- a/src/main/java/com/lothrazar/cyclic/block/placer/ContainerPlacer.java
+++ b/src/main/java/com/lothrazar/cyclic/block/placer/ContainerPlacer.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerPlacer extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerPlacer extends ContainerBase {
     super(ContainerScreenRegistry.placer, windowId);
     tile = (TilePlacer) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 80, 29));

--- a/src/main/java/com/lothrazar/cyclic/block/placerfluid/ContainerPlacerFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/placerfluid/ContainerPlacerFluid.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerPlacerFluid extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerPlacerFluid extends ContainerBase {
     super(ContainerScreenRegistry.placer_fluid, windowId);
     tile = (TilePlacerFluid) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 80, 29));

--- a/src/main/java/com/lothrazar/cyclic/block/screen/ContainerScreentext.java
+++ b/src/main/java/com/lothrazar/cyclic/block/screen/ContainerScreentext.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerScreentext extends ContainerBase {
 
@@ -18,7 +17,7 @@ public class ContainerScreentext extends ContainerBase {
     super(ContainerScreenRegistry.screen, windowId);
     tile = (TileScreentext) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     this.trackAllIntFields(tile, TileScreentext.Fields.values().length);
     trackEnergy(tile);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/shapebuilder/ContainerStructure.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapebuilder/ContainerStructure.java
@@ -12,7 +12,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerStructure extends ContainerBase {
 
@@ -22,7 +21,7 @@ public class ContainerStructure extends ContainerBase {
     super(ContainerScreenRegistry.structure, windowId);
     tile = (TileStructure) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       addSlot(new SlotItemHandler(h, TileStructure.SLOT_BUILD, 61, 21));
       addSlot(new SlotItemHandler(h, TileStructure.SLOT_SHAPE, 8, 132));

--- a/src/main/java/com/lothrazar/cyclic/block/shapedata/ContainerShapedata.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapedata/ContainerShapedata.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerShapedata extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerShapedata extends ContainerBase {
     super(ContainerScreenRegistry.computer_shape, windowId);
     tile = (TileShapedata) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 9, 29 + 18));

--- a/src/main/java/com/lothrazar/cyclic/block/solidifier/ContainerSolidifier.java
+++ b/src/main/java/com/lothrazar/cyclic/block/solidifier/ContainerSolidifier.java
@@ -14,7 +14,6 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerSolidifier extends ContainerBase {
 
@@ -24,7 +23,7 @@ public class ContainerSolidifier extends ContainerBase {
     super(ContainerScreenRegistry.solidifier, windowId);
     tile = (TileSolidifier) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 37, 17));

--- a/src/main/java/com/lothrazar/cyclic/block/uncrafter/ContainerUncraft.java
+++ b/src/main/java/com/lothrazar/cyclic/block/uncrafter/ContainerUncraft.java
@@ -11,7 +11,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerUncraft extends ContainerBase {
 
@@ -21,7 +20,7 @@ public class ContainerUncraft extends ContainerBase {
     super(ContainerScreenRegistry.uncraft, windowId);
     tile = (TileUncraft) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 80, 19));

--- a/src/main/java/com/lothrazar/cyclic/block/user/ContainerUser.java
+++ b/src/main/java/com/lothrazar/cyclic/block/user/ContainerUser.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerUser extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerUser extends ContainerBase {
     super(ContainerScreenRegistry.user, windowId);
     tile = (TileUser) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       addSlot(new SlotItemHandler(h, 0, 10, 35));

--- a/src/main/java/com/lothrazar/cyclic/block/wirelessredstone/ContainerTransmit.java
+++ b/src/main/java/com/lothrazar/cyclic/block/wirelessredstone/ContainerTransmit.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class ContainerTransmit extends ContainerBase {
 
@@ -20,7 +19,7 @@ public class ContainerTransmit extends ContainerBase {
     super(ContainerScreenRegistry.wireless_transmitter, windowId);
     tile = (TileWirelessTransmit) world.getTileEntity(pos);
     this.playerEntity = player;
-    this.playerInventory = new InvWrapper(playerInventory);
+    this.playerInventory = playerInventory;
     tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
       this.endInv = h.getSlots();
       for (int s = 0; s < h.getSlots(); s++) {


### PR DESCRIPTION
…nvTweaks is able to sort properly in Cyclic containers. Fixes #1574 and #1527 

simply removes the InvWrapper around the player's inventory in Cyclic Containers. I haven't noticed any downsides to doing this.