### PR TITLE
[1.16] Fix compatibility with Repurposed Structures mod

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/item/endereye/ItemEnderEyeReuse.java
+++ b/src/main/java/com/lothrazar/cyclic/item/endereye/ItemEnderEyeReuse.java
@@ -52,7 +52,6 @@ public class ItemEnderEyeReuse extends ItemBase {
       BlockPos rsBlockPos;
 
       if (ModList.get().isLoaded(RS_MODID)) {
-        ForgeRegistries.STRUCTURE_FEATURES.getKeys().forEach(k -> System.out.printf("%s, ", k.getNamespace() + k.getPath()));
         if (ForgeRegistries.STRUCTURE_FEATURES.containsKey(RS_RESOURCE_LOCATION)) {
           rsStronghold = ForgeRegistries.STRUCTURE_FEATURES.getValue(RS_RESOURCE_LOCATION);
           rsBlockPos = chunkGenerator.func_235956_a_(sw, rsStronghold, new BlockPos(player.getPosition()), 100, false);

--- a/src/main/java/com/lothrazar/cyclic/item/endereye/ItemEnderEyeReuse.java
+++ b/src/main/java/com/lothrazar/cyclic/item/endereye/ItemEnderEyeReuse.java
@@ -2,20 +2,25 @@ package com.lothrazar.cyclic.item.endereye;
 
 import com.lothrazar.cyclic.base.ItemBase;
 import com.lothrazar.cyclic.util.UtilItemStack;
+import com.lothrazar.cyclic.util.UtilWorld;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Stats;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.SoundEvents;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.feature.IFeatureConfig;
+import net.minecraft.world.gen.feature.StructureFeature;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nullable;
 
 public class ItemEnderEyeReuse extends ItemBase {
 
@@ -23,24 +28,52 @@ public class ItemEnderEyeReuse extends ItemBase {
     super(properties.maxDamage(256));
   }
 
+  //compat with Repurposed Structures Mod see #1517
+  private static final String RS_MODID = "repurposed_structures";
+  private static final String RS_STRONGHOLD_ID = "stronghold_stonebrick";
+  private static final String RS_NETHER_STRONGHOLD_ID = "stronghold_nether";
+  private static final ResourceLocation RS_RESOURCE_LOCATION = new ResourceLocation(RS_MODID, RS_STRONGHOLD_ID);
+  private static final ResourceLocation RS_NETHER_RESOURCE_LOCATION = new ResourceLocation(RS_MODID, RS_NETHER_STRONGHOLD_ID);
+
   @Override
   public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity player, Hand hand) {
+
     ItemStack stack = player.getHeldItem(hand);
     if (!worldIn.isRemote && worldIn instanceof ServerWorld) {
       ServerWorld sw = (ServerWorld) worldIn;
       ChunkGenerator chunkGenerator = sw.getChunkProvider().getChunkGenerator();
-      //      chunkGenerator.func_235956_a_(p_235956_1_, p_235956_2_, p_235956_3_, p_235956_4_, p_235956_5_)
-      //findNearestStructure 
-      BlockPos blockpos = chunkGenerator.func_235956_a_(sw, Structure.STRONGHOLD, new BlockPos(player.getPosition()), 100, false);
-      if (blockpos != null) {
+
+      //compat with Repurposed Structures Mod see #1517
+      Structure<?> vanillaStronghold = Structure.STRONGHOLD;
+      Structure<?> rsStronghold;
+      Structure<?> rsNetherStronghold;
+
+      BlockPos closestBlockPos = chunkGenerator.func_235956_a_(sw, vanillaStronghold, new BlockPos(player.getPosition()), 100, false);
+      BlockPos rsBlockPos;
+
+      if (ModList.get().isLoaded(RS_MODID)) {
+        ForgeRegistries.STRUCTURE_FEATURES.getKeys().forEach(k -> System.out.printf("%s, ", k.getNamespace() + k.getPath()));
+        if (ForgeRegistries.STRUCTURE_FEATURES.containsKey(RS_RESOURCE_LOCATION)) {
+          rsStronghold = ForgeRegistries.STRUCTURE_FEATURES.getValue(RS_RESOURCE_LOCATION);
+          rsBlockPos = chunkGenerator.func_235956_a_(sw, rsStronghold, new BlockPos(player.getPosition()), 100, false);
+          closestBlockPos = returnClosest(player.getPosition(), closestBlockPos, rsBlockPos);
+        }
+        if (ForgeRegistries.STRUCTURE_FEATURES.containsKey(RS_NETHER_RESOURCE_LOCATION)) {
+          rsNetherStronghold = ForgeRegistries.STRUCTURE_FEATURES.getValue(RS_NETHER_RESOURCE_LOCATION);
+          rsBlockPos = chunkGenerator.func_235956_a_(sw, rsNetherStronghold, new BlockPos(player.getPosition()), 100, false);
+          closestBlockPos = returnClosest(player.getPosition(), closestBlockPos, rsBlockPos);
+        }
+      }
+
+      if (closestBlockPos != null) {
         double posX = player.getPosX();
         double posY = player.getPosY();
         double posZ = player.getPosZ();
         EyeOfEnderEntityNodrop eyeofenderentity = new EyeOfEnderEntityNodrop(worldIn, posX, posY + player.getHeight() / 2.0F, posZ);
-        eyeofenderentity.moveTowards(blockpos);
+        eyeofenderentity.moveTowards(closestBlockPos);
         worldIn.addEntity(eyeofenderentity);
         if (player instanceof ServerPlayerEntity) {
-          CriteriaTriggers.USED_ENDER_EYE.trigger((ServerPlayerEntity) player, blockpos);
+          CriteriaTriggers.USED_ENDER_EYE.trigger((ServerPlayerEntity) player, closestBlockPos);
         }
         worldIn.playSound((PlayerEntity) null, posX, posY, posZ, SoundEvents.ENTITY_ENDER_EYE_LAUNCH, SoundCategory.NEUTRAL, 0.5F,
             0.4F / (random.nextFloat() * 0.4F + 0.8F));
@@ -48,8 +81,21 @@ public class ItemEnderEyeReuse extends ItemBase {
         UtilItemStack.damageItem(player, stack);
         player.addStat(Stats.ITEM_USED.get(this));
         player.getCooldownTracker().setCooldown(stack.getItem(), 10);
+        return ActionResult.resultSuccess(player.getHeldItem(hand));
       }
     }
     return super.onItemRightClick(worldIn, player, hand);
+  }
+
+  private BlockPos returnClosest(BlockPos playerPos, @Nullable BlockPos pos1, @Nullable BlockPos pos2) {
+    if (pos1 == null && pos2 == null)
+      return null;
+    else if (pos1 == null)
+      return pos2;
+    else if (pos2 == null)
+      return pos1;
+    else if (UtilWorld.distanceBetweenHorizontal(playerPos, pos1) <= UtilWorld.distanceBetweenHorizontal(playerPos, pos2))
+      return pos1;
+    return pos2;
   }
 }


### PR DESCRIPTION
Closes #1517. See comments there and https://github.com/TelepathicGrunt/RepurposedStructures/issues/38 here for more info.

tl;dr: RS replaces vanilla Stronghold so we have to detect presence of that mod and detect its version of Strongholds instead when present.

Also added the ability for Solid Ender Eye to find Nether Strongholds from RS Mod.