### PR TITLE
[1.16] Botania Compat, magnet + solegnolia

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,8 +114,11 @@ dependencies {
     compile fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}")
     compile fg.deobf("top.theillusivec4.curios:curios-forge:${mc_version}-${curios_version}")
     
-   compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
-   runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
+    compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
+    runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
+
+    compileOnly fg.deobf("vazkii.botania:Botania:${botania_version}:api")
+    runtimeOnly fg.deobf("vazkii.botania:Botania:${botania_version}")
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
     // compile "some.group:artifact:version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ mappings_version=20201028-1.16.3
 jei_version=7.6.0.58
 curios_version=4.0.2.1
 patchouli_version=1.16.2-47
+botania_version=1.16.3-409
 
 # folder to copy the build output jar
 dist_folder=c:/temp

--- a/src/main/java/com/lothrazar/cyclic/enchant/EnchantMagnet.java
+++ b/src/main/java/com/lothrazar/cyclic/enchant/EnchantMagnet.java
@@ -33,6 +33,8 @@ import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
+import vazkii.botania.api.BotaniaAPI;
 
 public class EnchantMagnet extends EnchantBase {
 
@@ -69,7 +71,8 @@ public class EnchantMagnet extends EnchantBase {
     }
     //Ticking
     int level = getLevelAll(entity);
-    if (level > 0) {
+    boolean solegnoliaPresent = ModList.get().isLoaded("botania") && BotaniaAPI.instance().hasSolegnoliaAround(entity);
+    if (level > 0 && !solegnoliaPresent) {
       UtilEntity.moveEntityItemsInRegion(entity.getEntityWorld(), entity.getPosition(), ITEM_HRADIUS + HRADIUS_PER_LEVEL * level, ITEM_VRADIUS);
     }
   }


### PR DESCRIPTION
Close #1448 although for version 1.16 (reported on 1.15). Magnet enchant will respect Botania's Solegnolia and not work if one is nearby.

Updates build.gradle and gradle.properties to build against Botania.