### PR TITLE
[1.16] Fix server crashes for Storage Bag and Workbench.

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/workbench/TileWorkbench.java
+++ b/src/main/java/com/lothrazar/cyclic/block/workbench/TileWorkbench.java
@@ -12,6 +12,7 @@ import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
@@ -25,10 +26,10 @@ public class TileWorkbench extends TileEntityBase implements INamedContainerProv
   private LazyOptional<IItemHandler> inventory = LazyOptional.of(() -> new ItemStackHandler(9));
   private LazyOptional<IItemHandler> output = LazyOptional.of(() -> new ItemStackHandler(1));
 
+  @Nonnull
   @Override
   public ITextComponent getDisplayName() {
-    return this.getBlockState().getBlock().getTranslatedName();
-    //        return new StringTextComponent(getType().getRegistryName().getPath());
+    return new StringTextComponent(getType().getRegistryName().getPath());
   }
 
   @Nullable

--- a/src/main/java/com/lothrazar/cyclic/net/PacketItemStackNBT.java
+++ b/src/main/java/com/lothrazar/cyclic/net/PacketItemStackNBT.java
@@ -62,7 +62,7 @@ public class PacketItemStackNBT extends PacketBase {
     packet.slot = buffer.readInt();
     packet.type = buffer.readByte();
     packet.stack = buffer.readItemStack();
-    packet.nbtKey = StringNBT.valueOf(buffer.readString());
+    packet.nbtKey = StringNBT.valueOf(buffer.readString(32767));
     switch (packet.type) {
       case 1: //Byte
         packet.nbtValue = ByteNBT.valueOf(buffer.readByte());
@@ -86,7 +86,7 @@ public class PacketItemStackNBT extends PacketBase {
         packet.nbtValue = new ByteArrayNBT(buffer.readByteArray());
       break;
       case 8: //String
-        packet.nbtValue = StringNBT.valueOf(buffer.readString());
+        packet.nbtValue = StringNBT.valueOf(buffer.readString(32767));
       break;
       case 9: //List... not sure of best way to handle this one since there's no constructor/setter. Look at other implementations?
         packet.nbtValue = new ListNBT();

--- a/src/main/java/com/lothrazar/cyclic/registry/TileRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/TileRegistry.java
@@ -218,5 +218,5 @@ public class TileRegistry {
   @ObjectHolder(ModCyclic.MODID + ":laser")
   public static TileEntityType<TileLaser> laser;
   @ObjectHolder(ModCyclic.MODID + ":workbench")
-  public static TileEntityType<TileCrafter> workbench;
+  public static TileEntityType<TileWorkbench> workbench;
 }


### PR DESCRIPTION
Fix #1641 crash when clicking on buttons in Storage Bag GUI because PacketBuffer#readString is client-side only. Use the server-side version.

Fix #1645 crash when opening Workbench on server, because Block#getTranslatedName() is client-side only.