### PR TITLE
Fix Disenchanter eating items

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/disenchant/ContainerDisenchant.java
+++ b/src/main/java/com/lothrazar/cyclic/block/disenchant/ContainerDisenchant.java
@@ -24,8 +24,8 @@ public class ContainerDisenchant extends ContainerBase {
     this.endInv = h.getSlots() + 1;//for shiftclick out of the out slot
     addSlot(new SlotItemHandler(h, 0, 24, 40));
     addSlot(new SlotItemHandler(h, 1, 48, 40));
-    addSlot(new SlotItemHandler(tile.outputSlot, 0, 124, 28));
-    addSlot(new SlotItemHandler(tile.outputSlot, 1, 124, 58));
+    addSlot(new DisenchantOutputSlot(tile.outputSlot, 0, 124, 28));
+    addSlot(new DisenchantOutputSlot(tile.outputSlot, 1, 124, 58));
     layoutPlayerInventorySlots(8, 84);
     trackEnergy(tile);
     this.trackAllIntFields(tile, TileDisenchant.Fields.values().length);

--- a/src/main/java/com/lothrazar/cyclic/block/disenchant/DisenchantOutputSlot.java
+++ b/src/main/java/com/lothrazar/cyclic/block/disenchant/DisenchantOutputSlot.java
@@ -1,0 +1,21 @@
+package com.lothrazar.cyclic.block.disenchant;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.SlotItemHandler;
+
+import javax.annotation.Nonnull;
+
+public class DisenchantOutputSlot extends SlotItemHandler {
+
+  public DisenchantOutputSlot(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
+    super(itemHandler, index, xPosition, yPosition);
+  }
+
+  @Override
+  public boolean isItemValid(@Nonnull ItemStack stack)
+  {
+    return false;
+  }
+
+}

--- a/src/main/java/com/lothrazar/cyclic/block/disenchant/TileDisenchant.java
+++ b/src/main/java/com/lothrazar/cyclic/block/disenchant/TileDisenchant.java
@@ -85,6 +85,7 @@ public class TileDisenchant extends TileEntityBase implements INamedContainerPro
     ItemStack book = inputSlots.getStackInSlot(SLOT_BOOK);
     if (book.getItem() != Items.BOOK
         || outputSlot.getStackInSlot(0).isEmpty() == false
+        || outputSlot.getStackInSlot(1).isEmpty() == false
         || input.getCount() != 1) {
       return;
     }


### PR DESCRIPTION
Added check for second slot output emptiness and disable player input into output slots, see https://github.com/Lothrazar/Cyclic/issues/1692