### PR TITLE
backport of 1.16 heart handling

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
+++ b/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
@@ -4,18 +4,19 @@ import com.lothrazar.cyclic.base.ItemEntityInteractable;
 import com.lothrazar.cyclic.block.cable.CableWrench;
 import com.lothrazar.cyclic.block.cable.WrenchActionType;
 import com.lothrazar.cyclic.block.scaffolding.ItemScaffolding;
+import com.lothrazar.cyclic.item.HeartItem;
 import com.lothrazar.cyclic.item.builder.BuilderActionType;
 import com.lothrazar.cyclic.item.builder.BuilderItem;
 import com.lothrazar.cyclic.registry.BlockRegistry;
 import com.lothrazar.cyclic.registry.SoundRegistry;
 import com.lothrazar.cyclic.util.UtilChat;
-import com.lothrazar.cyclic.util.UtilEntity;
 import com.lothrazar.cyclic.util.UtilItemStack;
 import com.lothrazar.cyclic.util.UtilSound;
 import com.lothrazar.cyclic.util.UtilWorld;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -37,7 +38,9 @@ public class ItemEvents {
   public void onPlayerCloneDeath(PlayerEvent.Clone event) {
     IAttributeInstance original = event.getOriginal().getAttribute(SharedMonsterAttributes.MAX_HEALTH);
     if (original != null) {
-      UtilEntity.setMaxHealth(event.getPlayer(), original.getValue());
+    	AttributeModifier healthModifier = original.getModifier(HeartItem.healthModifierUuid);
+        if (healthModifier != null)
+          event.getPlayer().getAttribute(SharedMonsterAttributes.MAX_HEALTH).applyModifier(healthModifier);
     }
   }
   //

--- a/src/main/java/com/lothrazar/cyclic/item/HeartItem.java
+++ b/src/main/java/com/lothrazar/cyclic/item/HeartItem.java
@@ -1,10 +1,12 @@
 package com.lothrazar.cyclic.item;
 
+import java.util.UUID;
+
 import com.lothrazar.cyclic.base.ItemBase;
 import com.lothrazar.cyclic.registry.SoundRegistry;
-import com.lothrazar.cyclic.util.UtilEntity;
 import com.lothrazar.cyclic.util.UtilSound;
 import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemUseContext;
@@ -14,7 +16,8 @@ public class HeartItem extends ItemBase {
 
   private static final int MAX = 100;
   private static final int COOLDOWN = 5000;
-
+  public static final UUID healthModifierUuid = UUID.fromString("06d30aa2-eff2-4a81-b92b-a1cb95f115c6");
+  
   public HeartItem(Properties properties) {
     super(properties);
     //see ItemEvents for saving hearts on death
@@ -28,11 +31,21 @@ public class HeartItem extends ItemBase {
     }
     player.getFoodStats().addStats(1, 4);
     IAttributeInstance healthAttribute = player.getAttribute(SharedMonsterAttributes.MAX_HEALTH);
+    
     if (healthAttribute.getValue() < MAX) {
-      UtilEntity.incrementMaxHealth(player, 2);
-      player.getCooldownTracker().setCooldown(this, COOLDOWN);
-      player.getHeldItem(context.getHand()).shrink(1);
-      UtilSound.playSound(player, SoundRegistry.fill);
+    	//get attribute modif by id
+        AttributeModifier oldHealthModifier = healthAttribute.getModifier(healthModifierUuid);
+        //what is our value
+        double addedHealth = (oldHealthModifier == null) ? +2.0D : oldHealthModifier.getAmount() + 2.0D;
+        //replace the modifier on the main attribute
+        healthAttribute.removeModifier(healthModifierUuid);
+        AttributeModifier healthModifier = new AttributeModifier(healthModifierUuid, "HP Bonus from Cyclic", addedHealth, AttributeModifier.Operation.ADDITION);
+        healthAttribute.applyModifier(healthModifier);
+        //finish up
+        player.getCooldownTracker().setCooldown(this, COOLDOWN);
+        player.getHeldItem(context.getHand()).shrink(1);
+        UtilSound.playSound(player, SoundRegistry.fill);
+    	
     }
     return super.onItemUse(context);
   }


### PR DESCRIPTION
Backported the handling for heartitem and hearttoxicitem found in the current 1.16 branch to fix #1703 
