### PR TITLE
changed ingame manual text to reflect changed behaviour

### DIFF
--- a/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/src/main/resources/assets/cyclic/lang/en_us.json
@@ -130,7 +130,7 @@
 
     "block.cyclic.conveyor": "Conveyor Belt",
     "block.cyclic.conveyor.tooltip": "Conveyor with many settings to move entities",
-    "block.cyclic.conveyor.guide": "Moves all entities standing on it.   Many properties of this block are stored in the blockstate such as type, speed, and dye color.  Types include straight, corner, and up/down ramps.  To toggle the type, place in world and use the wooden wrench on the placed rail, this toggles the type.",
+    "block.cyclic.conveyor.guide": "Moves all entities standing on it.   Many properties of this block are stored in the blockstate such as type, speed, and dye color.  Types include straight, corner, and up/down ramps.  To toggle the type, place in world and use the $(l:items/wrench)Wooden Wrench$(/l) on the placed rail, this toggles the type.",
     "block.cyclic.conveyor.guide0": "Hold a redstone torch and interact to toggle the speed.   Hold dye and use it on the block to toggle the color.  These updates propogate to nearby connected rails.  (check F3 to view these properties in detail) ",
 
 

--- a/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/src/main/resources/assets/cyclic/lang/en_us.json
@@ -130,7 +130,7 @@
 
     "block.cyclic.conveyor": "Conveyor Belt",
     "block.cyclic.conveyor.tooltip": "Conveyor with many settings to move entities",
-    "block.cyclic.conveyor.guide": "Moves all entities standing on it.   Many properties of this block are stored in the blockstate such as type, speed, and dye color.  Types include straight, corner, and up/down ramps.  To toggle the type, place in world and use another rail on the placed rail, this toggles the type.",
+    "block.cyclic.conveyor.guide": "Moves all entities standing on it.   Many properties of this block are stored in the blockstate such as type, speed, and dye color.  Types include straight, corner, and up/down ramps.  To toggle the type, place in world and use the wooden wrench on the placed rail, this toggles the type.",
     "block.cyclic.conveyor.guide0": "Hold a redstone torch and interact to toggle the speed.   Hold dye and use it on the block to toggle the color.  These updates propogate to nearby connected rails.  (check F3 to view these properties in detail) ",
 
 


### PR DESCRIPTION
While looking at the manual for https://github.com/Lothrazar/Cyclic/issues/1701 to make sure the information was in-game, I noticed a mismatch between the text and the behavior in 
https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/block/conveyor/BlockConveyor.java#L220

I've updated the manual text. If you want the change to happen the other way let me know but I think the wrench makes the most sense. 