### PR TITLE
Fix part of #1661 by marking the output slot as an output

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/solidifier/ContainerSolidifier.java
+++ b/src/main/java/com/lothrazar/cyclic/block/solidifier/ContainerSolidifier.java
@@ -23,13 +23,12 @@ public class ContainerSolidifier extends ContainerBase {
     tile = (TileSolidifier) world.getTileEntity(pos);
     this.playerEntity = player;
     this.playerInventory = playerInventory;
-    //move it
-    addSlot(new SlotItemHandler(tile.outputSlot, 0, 121, 31));
     ItemStackHandler h = tile.inputSlots;
-    this.endInv = h.getSlots() + 1; //for shiftclick out of the out slot
     addSlot(new SlotItemHandler(h, 0, 37, 17));
     addSlot(new SlotItemHandler(h, 1, 37, 17 + Const.SQ));
     addSlot(new SlotItemHandler(h, 2, 37, 17 + 2 * Const.SQ));
+    addSlot(new SlotItemHandler(tile.outputSlot, 0, 121, 31));
+    this.endInv = h.getSlots() + 1; //for shiftclick out of the out slot
     layoutPlayerInventorySlots(8, 84);
     this.trackAllIntFields(tile, TileSolidifier.Fields.values().length);
     trackEnergy(tile);

--- a/src/main/java/com/lothrazar/cyclic/compat/jei/CyclicPluginJEI.java
+++ b/src/main/java/com/lothrazar/cyclic/compat/jei/CyclicPluginJEI.java
@@ -71,8 +71,7 @@ public class CyclicPluginJEI implements IModPlugin {
         0, 2, //recipeSLotStart, recipeSlotCount
         2, PLAYER_INV_SIZE); // inventorySlotStart, inventorySlotCount
     registry.addRecipeTransferHandler(ContainerSolidifier.class, SolidifierRecipeCategory.ID,
-        //second part should be 3 not 4, but i think JEI has a bug or something
-        1, 4, //recipeSLotStart, recipeSlotCount
+        0, 3, //recipeSLotStart, recipeSlotCount
         4, PLAYER_INV_SIZE); // inventorySlotStart, inventorySlotCount
     registry.addRecipeTransferHandler(ContainerCrafter.class, VanillaRecipeCategoryUid.CRAFTING,
         10, 9, //recipeSLotStart, recipeSlotCount

--- a/src/main/java/com/lothrazar/cyclic/compat/jei/SolidifierRecipeCategory.java
+++ b/src/main/java/com/lothrazar/cyclic/compat/jei/SolidifierRecipeCategory.java
@@ -82,7 +82,7 @@ public class SolidifierRecipeCategory implements IRecipeCategory<RecipeSolidifie
     guiItemStacks.init(0, true, 33, 6);
     guiItemStacks.init(1, true, 33, 6 + Const.SQ);
     guiItemStacks.init(2, true, 33, 6 + 2 * Const.SQ);
-    guiItemStacks.init(3, true, 104, 6 + Const.SQ);
+    guiItemStacks.init(3, false, 104, 6 + Const.SQ);
     guiItemStacks.set(3, recipe.getRecipeOutput());
     List<List<ItemStack>> inputs = ingredients.getInputs(VanillaTypes.ITEM);
     List<ItemStack> input = null;


### PR DESCRIPTION
This only fixes partially #1661 since it's really two issues rolled into one. The extraction being broken, and the JEI completion being broken. The latter is what this PR addresses.

**Changes**
- Fixed the output slot in `SolidifierRecipeCategory` was marked as an input slot.
- Fixed inconsistent slots
It was `Ouput(0)` and `Inputs(1,2,3)` for [`addRecipeTransferHandler`](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/compat/jei/CyclicPluginJEI.java#L73-L76)
It was a mix for [`ContainerSolidifier`](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/block/solidifier/ContainerSolidifier.java#L27-L29)
And it was `Inputs(0,1,2)` and `Ouput(3)` for [`SolidifierRecipeCategory`](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/compat/jei/SolidifierRecipeCategory.java#L82-L86) as well as for the underlying inventory storage afaict.
I decided to go with the the last for consistency since it seemed to be the intention when looking at `ItemStackHandlerWrapper`

**Remaining Analysis (for future PR)**
The implementation of `ItemStackHandlerWrapper` has some problems.
- It is declaring the slot number to be [input slots + output slots](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/capability/ItemStackHandlerWrapper.java#L12)
- From what I can tell it's treating the [first set of slots as the input slots](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/capability/ItemStackHandlerWrapper.java#L18-L23) but that [overlaps with the output slots for extraction](https://github.com/Lothrazar/Cyclic/blob/084b56403dba202b1eb15bdc7a1b5c1ca0e5591a/src/main/java/com/lothrazar/cyclic/capability/ItemStackHandlerWrapper.java#L26-L30).
- Also it doesn't override enough methods from `ItemStackHandler` which can lead to strange things happening. The serialisation of it is inconsistent, seems like the backing handlers (input and output) are usually serialized. But there's a creative only block `TileItemInfinite` that serialises the wrong thing (it'll always be empty). But it seems the block isn't fully implemented yet so maybe a breaking change for it is okay?

As an example if there's 3 inputs slots, they'll be `0, 1, 2` and if there's one output slot it'll be `0` leaving slot `3` unsued.

**Screenshots**
<details>
<summary>Click to Expand</summary>

JEI no longer uses output slot as an input slot
![2021-01-20_21 20 45](https://user-images.githubusercontent.com/630920/105186020-35138780-5b6c-11eb-9ebd-5c172dff1ee9.png)
It finished too fast XD
![2021-01-20_21 20 47](https://user-images.githubusercontent.com/630920/105186183-67bd8000-5b6c-11eb-8200-937ac382bd85.png)
Evenly divide with shift completion
![2021-01-20_21 20 59](https://user-images.githubusercontent.com/630920/105186251-7dcb4080-5b6c-11eb-9190-8d3ac2c79671.png)