### PR TITLE
Fix bag pickup crash

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
+++ b/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
@@ -18,7 +18,6 @@ import com.lothrazar.cyclic.util.UtilChat;
 import com.lothrazar.cyclic.util.UtilItemStack;
 import com.lothrazar.cyclic.util.UtilSound;
 import com.lothrazar.cyclic.util.UtilWorld;
-import java.util.Set;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.LivingEntity;
@@ -216,8 +215,7 @@ public class ItemEvents {
       ItemEntity itemEntity = event.getItem();
       ItemStack resultStack = itemEntity.getItem();
       int origCount = resultStack.getCount();
-      Set<Integer> bagSlots = StorageBagItem.getAllBagSlots(player);
-      for (Integer i : bagSlots) {
+      for (Integer i : StorageBagItem.getAllBagSlots(player)) {
         ItemStack bag = player.inventory.getStackInSlot(i);
         switch (StorageBagItem.getPickupMode(bag)) {
           case EVERYTHING:

--- a/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
+++ b/src/main/java/com/lothrazar/cyclic/event/ItemEvents.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
+import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.EffectInstance;
@@ -212,32 +213,29 @@ public class ItemEvents {
   public void onPlayerPickup(EntityItemPickupEvent event) {
     if (event.getEntityLiving() instanceof PlayerEntity) {
       PlayerEntity player = (PlayerEntity) event.getEntityLiving();
-      ItemStack stack = event.getItem().getItem();
-      ItemStack resultStack = null;
+      ItemEntity itemEntity = event.getItem();
+      ItemStack resultStack = itemEntity.getItem();
+      int origCount = resultStack.getCount();
       Set<Integer> bagSlots = StorageBagItem.getAllBagSlots(player);
       for (Integer i : bagSlots) {
         ItemStack bag = player.inventory.getStackInSlot(i);
         switch (StorageBagItem.getPickupMode(bag)) {
           case EVERYTHING:
             resultStack = StorageBagItem.tryInsert(bag, resultStack);
-            event.getItem().setItem(resultStack);
           break;
           case FILTER:
             resultStack = StorageBagItem.tryFilteredInsert(bag, resultStack);
-            event.getItem().setItem(resultStack);
           break;
           case NOTHING:
           break;
         }
-        if (resultStack == ItemStack.EMPTY) {
+        if (resultStack.isEmpty()) {
           break;
         }
       }
-      if (resultStack != null && resultStack.getCount() != stack.getCount()) {
+      if (resultStack.getCount() != origCount) {
+        itemEntity.setItem(resultStack);
         event.setResult(Result.ALLOW);
-      }
-      else {
-        event.setResult(Result.DEFAULT);
       }
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/item/storagebag/StorageBagItem.java
+++ b/src/main/java/com/lothrazar/cyclic/item/storagebag/StorageBagItem.java
@@ -2,6 +2,7 @@ package com.lothrazar.cyclic.item.storagebag;
 
 import com.lothrazar.cyclic.base.ItemBase;
 import com.lothrazar.cyclic.registry.ContainerScreenRegistry;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -310,8 +311,8 @@ public class StorageBagItem extends ItemBase {
     return RefillMode.NOTHING;
   }
 
-  public static Set<Integer> getAllBagSlots(PlayerEntity player) {
-    Set<Integer> slots = new HashSet<>();
+  public static List<Integer> getAllBagSlots(PlayerEntity player) {
+    List<Integer> slots = new ArrayList<>();
     for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
       if (isBag(player.inventory.getStackInSlot(i))) {
         slots.add(i);


### PR DESCRIPTION
Fixes #1775.

Changes in PR:

- Changed result stack from being null to being the ItemEntity's ItemStack.
- Fixed some of the logic for setting to result `ALLOW` to save the count instead of saving item stack and comparing to `ItemStack.EMPTY` instead of using `isEmpty()`.
- Removed setting result to `DEFAULT` if the count didn't change because that would break if another mod collected some items into a bag before we got to it.

Also a bit unrelated because I saw it while working on this:

- Includes a commit that makes the bag order consistent by using an ArrayList instead of a HashSet (follows vanilla's hotbar then rest of inventory rows). Let me know if this is not desired and I will remove the commit.