### PR TITLE
Fix AutoCaveTorchItem to only place torches on valid surfaces

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/util/UtilPlaceBlocks.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilPlaceBlocks.java
@@ -1,11 +1,9 @@
 package com.lothrazar.cyclic.util;
 
 import com.lothrazar.cyclic.ModCyclic;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.WallTorchBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.BlockItemUseContext;
@@ -13,7 +11,6 @@ import net.minecraft.item.DirectionalPlaceContext;
 import net.minecraft.item.Items;
 import net.minecraft.state.Property;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
@@ -153,8 +150,8 @@ public class UtilPlaceBlocks {
   }
 
   public static boolean placeTorchSafely(World world, BlockPos blockPos) {
-  	BlockItem torch = (BlockItem) Items.TORCH;
-  	BlockItemUseContext context = new DirectionalPlaceContext(world, blockPos, Direction.DOWN, Items.TORCH.getDefaultInstance(), Direction.DOWN);
-  	return torch.tryPlace(context).isSuccessOrConsume();
+    BlockItem torch = (BlockItem) Items.TORCH;
+    BlockItemUseContext context = new DirectionalPlaceContext(world, blockPos, Direction.DOWN, Items.TORCH.getDefaultInstance(), Direction.DOWN);
+    return torch.tryPlace(context).isSuccessOrConsume();
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/util/UtilPlaceBlocks.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilPlaceBlocks.java
@@ -1,13 +1,19 @@
 package com.lothrazar.cyclic.util;
 
 import com.lothrazar.cyclic.ModCyclic;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.WallTorchBlock;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.item.DirectionalPlaceContext;
+import net.minecraft.item.Items;
 import net.minecraft.state.Property;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
@@ -147,34 +153,8 @@ public class UtilPlaceBlocks {
   }
 
   public static boolean placeTorchSafely(World world, BlockPos blockPos) {
-    Direction actual = findFirstSolidFace(world, blockPos, Direction.DOWN);
-    if (actual == null) {
-      return false;
-    }
-    if (actual.getAxis().isHorizontal()) {
-      world.setBlockState(blockPos, Blocks.WALL_TORCH.getDefaultState().with(WallTorchBlock.HORIZONTAL_FACING, actual));
-      return true;
-    }
-    else if (actual != Direction.DOWN) {
-      world.setBlockState(blockPos, Blocks.TORCH.getDefaultState());
-      return true;
-    }
-    return false;
-  }
-
-  public static Direction findFirstSolidFace(World world, BlockPos blockPos, Direction prefer) {
-    Direction actual = null;
-    Direction[] alternatives = { Direction.DOWN, Direction.EAST, Direction.WEST, Direction.NORTH, Direction.SOUTH, Direction.UP };
-    if (world.getBlockState(blockPos.offset(prefer)).isSolid()) {
-      actual = prefer;
-    }
-    else {
-      for (Direction dir : alternatives) {
-        if (world.getBlockState(blockPos.offset(dir)).isSolid()) {
-          actual = dir;
-        }
-      }
-    }
-    return actual == null ? null : actual.getOpposite();
+  	BlockItem torch = (BlockItem) Items.TORCH;
+  	BlockItemUseContext context = new DirectionalPlaceContext(world, blockPos, Direction.DOWN, Items.TORCH.getDefaultInstance(), Direction.DOWN);
+  	return torch.tryPlace(context).isSuccessOrConsume();
   }
 }


### PR DESCRIPTION
This commit changes the behavior of the AutoCaveTorchItem to be more
stringent regarding the placement of torches. This is done by using the
tryPlace() method of the BlockItem class, to make sure that the surface
is a valid placement for torches. This a fix (at least for one of the
mentioned problems) for issue #1801.