### PR TITLE
Add hook for custom Harvester logic (Compatibility reasons)

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/harvester/IHarvesterOverride.java
+++ b/src/main/java/com/lothrazar/cyclic/block/harvester/IHarvesterOverride.java
@@ -1,0 +1,31 @@
+package com.lothrazar.cyclic.block.harvester;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.function.Consumer;
+
+public interface IHarvesterOverride {
+    /**
+     * Checks if this harvesting logic applies to a certain block
+     *
+     * @param state the state of the block
+     * @param world the world
+     * @param pos the position
+     * @return true if this logic handles the given block
+     */
+    boolean appliesTo(BlockState state, World world, BlockPos pos);
+
+    /**
+     * Attempts to harvest and run custom harvest logic for a block at the given position.
+     *
+     * @param state the state of the block
+     * @param world the world
+     * @param pos the position
+     * @param dropConsumer pass any drops resulting from the harvest operation
+     * @return true if the harvesting operation was successfully handled
+     */
+    boolean attemptHarvest(BlockState state, World world, BlockPos pos, Consumer<ItemStack> dropConsumer);
+}


### PR DESCRIPTION
I am looking to implement compatibility for my [Crop Breeding mod](https://github.com/AgriCraft/AgriCraft) with Cyclic's harvester, however I found that there is no clear way to access, modify or otherwise override Cyclic's harvester logic without having to resort to mixins or other low level injections.

Therefore I provide you here with a PR containing a proposition on how a compatibility layer could look like.
I am not sure what your opinion on the matter is, but I would be glad to hear it.

This implementation, instead of running hard coded if() {statement} blocks, checks a crop against a pre-defined list of harvest logic objects to check if one of these logic implementations can handle the harvesting of the specific crop.
This way, mods with more exotic crops, like mine, can register their own custom logic for harvesting.

Ideally this would go into an API, however since Cyclic does not seem to currently have an API, I have decided to put it in the harvester package.