### PR TITLE
Resolve TODO for raw usage of parameterized type

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/event/EventPlayerData.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/event/EventPlayerData.java
@@ -28,6 +28,7 @@ import com.lothrazar.cyclicmagic.capability.PlayerCapInstance;
 import com.lothrazar.cyclicmagic.registry.CapabilityRegistry;
 import com.lothrazar.cyclicmagic.util.Const;
 import com.lothrazar.cyclicmagic.util.UtilEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
@@ -79,19 +80,8 @@ public class EventPlayerData {
     }
   }
 
-  /**
-   * 
-   * TODO
-   * 
-   * SHOULD BE AttachCapabilitiesEvent<EntityPlayer> ..BUT that NEVER EVER fires, so data never gets attached to player soo NPEs all over crash the game SO IM forced to do it this way, fire it on
-   * GLOBAL object and check instanceof at runtime NO IDEA if its a bug in forge or if there is a right way / wrong way. but of course forge has no docs and nobody to ask
-   * 
-   * @param event
-   */
-  @SuppressWarnings("rawtypes")
   @SubscribeEvent
-  public void onEntityConstruct(AttachCapabilitiesEvent event) {
-    //was AttachCapabilitiesEvent.Entity in 1.11 and previous
+  public void onEntityConstruct(AttachCapabilitiesEvent<Entity> event) {
     if (event.getObject() instanceof EntityPlayer) {
       event.addCapability(new ResourceLocation(Const.MODID, "IModdedSleeping"), new PlayerCapInstance());
     }


### PR DESCRIPTION
As you can see in `ForgeEventFactory#gatherCapabilities` there are only six capabilities that are in use (`TileEntity`, `Entity`, `Village`, `ItemStack`, `World` and `Chunk`). So of course it will never get called for `EntityPlayer` but we can just use `Entity` instead.