### PR TITLE
Check if fluids exist before adding melter recipe

### DIFF
--- a/src/main/java/com/lothrazar/cyclicmagic/block/melter/RecipeMelter.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/melter/RecipeMelter.java
@@ -204,56 +204,70 @@ public class RecipeMelter extends IForgeRegistryEntry.Impl<IRecipe> implements I
           new ItemStack[] { new ItemStack(Items.BONE), new ItemStack(Items.ROTTEN_FLESH), new ItemStack(Items.SPIDER_EYE), new ItemStack(Items.GUNPOWDER) },
           "xpjuice", 10));
     }
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.LOG2) },
-        "amber", 100));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.LOG2), new ItemStack(Blocks.LOG2),
-            new ItemStack(Blocks.VINE), new ItemStack(Blocks.NETHERRACK) },
-        "amber", 1000));
-    Item amber = Item.getByNameOrId(Const.MODRES + "crystallized_amber");
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(amber) },
-        "amber", 1000));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.POISONOUS_POTATO) },
-        "poison", 2000));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.FERMENTED_SPIDER_EYE), new ItemStack(Items.FERMENTED_SPIDER_EYE),
-            new ItemStack(Items.ROTTEN_FLESH), new ItemStack(Items.ROTTEN_FLESH) },
-        "poison", 500));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.OBSIDIAN), new ItemStack(Blocks.OBSIDIAN), new ItemStack(Items.EMERALD), new ItemStack(amber) },
-        "crystal", 1000));
-    Item crystal = Item.getByNameOrId(Const.MODRES + "crystallized_obsidian");
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(crystal) },
-        "crystal", 1000));
-    Item biomass = Item.getByNameOrId(Const.MODRES + "peat_biomass");
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(biomass) },
-        "biomass", 1000));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.WATERLILY) },
-        "biomass", 100));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.CARROT) },
-        "biomass", 100));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.VINE) },
-        "biomass", 50));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.CACTUS) },
-        "biomass", 50));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Blocks.TALLGRASS) },
-        "biomass", 25));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.WHEAT_SEEDS) },
-        "biomass", 25));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.APPLE) },
-        "biomass", 100));
+    if (FluidRegistry.isFluidRegistered("amber")) {
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.LOG2) },
+          "amber", 100));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.LOG2), new ItemStack(Blocks.LOG2),
+              new ItemStack(Blocks.VINE), new ItemStack(Blocks.NETHERRACK) },
+          "amber", 1000));
+      Item amber = Item.getByNameOrId(Const.MODRES + "crystallized_amber");
+      if (amber != null) {
+        addRecipe(new RecipeMelter(
+            new ItemStack[] { new ItemStack(amber) },
+            "amber", 1000));
+      }
+    }
+    if (FluidRegistry.isFluidRegistered("poison")) {
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.POISONOUS_POTATO) },
+          "poison", 2000));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.FERMENTED_SPIDER_EYE), new ItemStack(Items.FERMENTED_SPIDER_EYE),
+              new ItemStack(Items.ROTTEN_FLESH), new ItemStack(Items.ROTTEN_FLESH) },
+          "poison", 500));
+    }
+    if (FluidRegistry.isFluidRegistered("crystal")) {
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.OBSIDIAN), new ItemStack(Blocks.OBSIDIAN), new ItemStack(Items.EMERALD), new ItemStack(amber) },
+          "crystal", 1000));
+      Item crystal = Item.getByNameOrId(Const.MODRES + "crystallized_obsidian");
+      if (crystal != null) {
+        addRecipe(new RecipeMelter(
+            new ItemStack[] { new ItemStack(crystal) },
+            "crystal", 1000));
+      }
+    }
+    if (FluidRegistry.isFluidRegistered("biomass")) {
+      Item biomass = Item.getByNameOrId(Const.MODRES + "peat_biomass");
+      if (biomass != null) {
+        addRecipe(new RecipeMelter(
+            new ItemStack[] { new ItemStack(biomass) },
+            "biomass", 1000));
+      }
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.WATERLILY) },
+          "biomass", 100));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.CARROT) },
+          "biomass", 100));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.VINE) },
+          "biomass", 50));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.CACTUS) },
+          "biomass", 50));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Blocks.TALLGRASS) },
+          "biomass", 25));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.WHEAT_SEEDS) },
+          "biomass", 25));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.APPLE) },
+          "biomass", 100));
+    }
   }
 
   public static void addRecipe(RecipeMelter rec) {

--- a/src/main/java/com/lothrazar/cyclicmagic/block/melter/RecipeMelter.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/melter/RecipeMelter.java
@@ -26,6 +26,7 @@ package com.lothrazar.cyclicmagic.block.melter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import com.lothrazar.cyclicmagic.registry.FluidsRegistry;
 import com.lothrazar.cyclicmagic.util.Const;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -195,12 +196,14 @@ public class RecipeMelter extends IForgeRegistryEntry.Impl<IRecipe> implements I
     addRecipe(new RecipeMelter(
         new ItemStack[] { new ItemStack(Blocks.OBSIDIAN) },
         "lava", 1000));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.GHAST_TEAR) },
-        "xpjuice", 10));
-    addRecipe(new RecipeMelter(
-        new ItemStack[] { new ItemStack(Items.BONE), new ItemStack(Items.ROTTEN_FLESH), new ItemStack(Items.SPIDER_EYE), new ItemStack(Items.GUNPOWDER) },
-        "xpjuice", 10));
+    if (FluidsRegistry.fluid_exp != null) {
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.GHAST_TEAR) },
+          "xpjuice", 10));
+      addRecipe(new RecipeMelter(
+          new ItemStack[] { new ItemStack(Items.BONE), new ItemStack(Items.ROTTEN_FLESH), new ItemStack(Items.SPIDER_EYE), new ItemStack(Items.GUNPOWDER) },
+          "xpjuice", 10));
+    }
     addRecipe(new RecipeMelter(
         new ItemStack[] { new ItemStack(Blocks.LOG2) },
         "amber", 100));

--- a/src/main/java/com/lothrazar/cyclicmagic/block/solidifier/RecipeSolidifier.java
+++ b/src/main/java/com/lothrazar/cyclicmagic/block/solidifier/RecipeSolidifier.java
@@ -208,44 +208,61 @@ public class RecipeSolidifier extends IForgeRegistryEntry.Impl<IRecipe> implemen
     }, new ItemStack(Blocks.OBSIDIAN),
         "lava", 1000));
     addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.BUCKET)
-    }, new ItemStack(Items.MILK_BUCKET),
-        "milk", 1000));
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.ARROW)
-    }, PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW), PotionTypes.STRONG_POISON),
-        "poison", 100));
-    //    addRecipe(new RecipeSolidifier(new ItemStack[] {
-    //        new ItemStack(Items.ARROW)
-    //    }, PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW), ItemPotionContent.potionTypeButterII),
-    //        "poison", 100));
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
         new ItemStack(Items.ARROW), new ItemStack(Items.ARROW), new ItemStack(Items.ARROW), new ItemStack(Items.FLINT)
     }, PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW, 3), PotionTypes.STRONG_HARMING),
         "lava", 500));
-    Item amber = Item.getByNameOrId(Const.MODRES + "crystallized_amber");
     addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.GOLD_NUGGET)
-    }, new ItemStack(amber), "amber", 1000));
-    Item crystal = Item.getByNameOrId(Const.MODRES + "crystallized_obsidian");
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.IRON_NUGGET)
-    }, new ItemStack(crystal),
-        "crystal", 1000));
-    Item biomass = Item.getByNameOrId(Const.MODRES + "peat_biomass");
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.WHEAT_SEEDS)
-    }, new ItemStack(biomass),
-        "biomass", 1000));
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Items.APPLE)
-    }, new ItemStack(biomass),
-        "biomass", 800));
-    Item peat = Item.getByNameOrId(Const.MODRES + "peat_unbaked");
-    addRecipe(new RecipeSolidifier(new ItemStack[] {
-        new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT)
-    }, new ItemStack(peat, 2),
-        "biomass", 100));
+        new ItemStack(Items.BUCKET)
+    }, new ItemStack(Items.MILK_BUCKET),
+        "milk", 1000));
+    if (FluidRegistry.isFluidRegistered("poison")) {
+      addRecipe(new RecipeSolidifier(new ItemStack[] {
+          new ItemStack(Items.ARROW)
+      }, PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW), PotionTypes.STRONG_POISON),
+          "poison", 100));
+      // addRecipe(new RecipeSolidifier(new ItemStack[] {
+      //     new ItemStack(Items.ARROW)
+      // }, PotionUtils.addPotionToItemStack(new ItemStack(Items.TIPPED_ARROW), ItemPotionContent.potionTypeButterII),
+      //     "poison", 100));
+    }
+    if (FluidRegistry.isFluidRegistered("amber")) {
+      Item amber = Item.getByNameOrId(Const.MODRES + "crystallized_amber");
+      if (amber != null) {
+        addRecipe(new RecipeSolidifier(new ItemStack[] {
+            new ItemStack(Items.GOLD_NUGGET)
+        }, new ItemStack(amber), 
+            "amber", 1000));
+      }
+    }
+    if (FluidRegistry.isFluidRegistered("crystal")) {
+      Item crystal = Item.getByNameOrId(Const.MODRES + "crystallized_obsidian");
+      if (crystal != null) {
+        addRecipe(new RecipeSolidifier(new ItemStack[] {
+            new ItemStack(Items.IRON_NUGGET)
+        }, new ItemStack(crystal),
+            "crystal", 1000));
+      }
+    }
+    if (FluidRegistry.isFluidRegistered("biomass")) {
+      Item biomass = Item.getByNameOrId(Const.MODRES + "peat_biomass");
+      if (biomass != null) {
+        addRecipe(new RecipeSolidifier(new ItemStack[] {
+            new ItemStack(Items.WHEAT_SEEDS)
+        }, new ItemStack(biomass),
+            "biomass", 1000));
+        addRecipe(new RecipeSolidifier(new ItemStack[] {
+            new ItemStack(Items.APPLE)
+        }, new ItemStack(biomass),
+            "biomass", 800));
+      }
+      Item peat = Item.getByNameOrId(Const.MODRES + "peat_unbaked");
+      if (peat != null) {
+        addRecipe(new RecipeSolidifier(new ItemStack[] {
+            new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT), new ItemStack(Blocks.DIRT)
+        }, new ItemStack(peat, 2),
+            "biomass", 100));
+      }
+    }
   }
 
   public static void addRecipe(RecipeSolidifier rec) {


### PR DESCRIPTION
If both the Enchanter and XP Pylon are turned off, the xp juice fluid never gets registered. Since the melter adds by default a recipe using the xp juice, this throws an error when registering the recipes as shown below. This PR aims to fix the errors by not registering those particular recipes if fluid_exp is null.

Similar errors are caused by other fluids not being registered, so this PR also aims to fix those.

```
[16:05:45] [Client thread/WARN]: ****************************************
[16:05:45] [Client thread/WARN]: * Null fluid supplied to fluidstack. Did you try and create a stack for an unregistered fluid?
[16:05:45] [Client thread/WARN]: *  at net.minecraftforge.fluids.FluidStack.<init>(FluidStack.java:48)
[16:05:45] [Client thread/WARN]: *  at com.lothrazar.cyclicmagic.block.melter.RecipeMelter.getOutputFluid(RecipeMelter.java:172)
[16:05:45] [Client thread/WARN]: *  at com.lothrazar.cyclicmagic.compat.jei.MelterWrapper.getIngredients(MelterWrapper.java:26)
[16:05:45] [Client thread/WARN]: *  at mezz.jei.recipes.RecipeRegistry.getIngredients(RecipeRegistry.java:290)
[16:05:45] [Client thread/WARN]: *  at mezz.jei.recipes.RecipeRegistry.addRecipeUnchecked(RecipeRegistry.java:274)
[16:05:45] [Client thread/WARN]: *  at mezz.jei.recipes.RecipeRegistry.addRecipe(RecipeRegistry.java:262)...
[16:05:45] [Client thread/WARN]: ****************************************

Found a broken recipe: Cyclic cyclicmagic:melter_6abfe965-9ca4-4b87-8182-1be960e937c8xpjuice class com.lothrazar.cyclicmagic.block.melter.RecipeMelter
Failed to get ingredients from recipe wrapper

java.lang.IllegalArgumentException: Cannot create a fluidstack from a null fluid
	at net.minecraftforge.fluids.FluidStack.<init>(FluidStack.java:49) ~[FluidStack.class:?]
	at com.lothrazar.cyclicmagic.block.melter.RecipeMelter.getOutputFluid(RecipeMelter.java:172) ~[RecipeMelter.class:?]
	at com.lothrazar.cyclicmagic.compat.jei.MelterWrapper.getIngredients(MelterWrapper.java:26) ~[MelterWrapper.class:?]
	at mezz.jei.recipes.RecipeRegistry.getIngredients(RecipeRegistry.java:290) ~[RecipeRegistry.class:?]
	at mezz.jei.recipes.RecipeRegistry.addRecipeUnchecked(RecipeRegistry.java:274) ~[RecipeRegistry.class:?]
	at mezz.jei.recipes.RecipeRegistry.addRecipe(RecipeRegistry.java:262) [RecipeRegistry.class:?]
	at mezz.jei.recipes.RecipeRegistry.addRecipe(RecipeRegistry.java:234) [RecipeRegistry.class:?]
	at mezz.jei.recipes.RecipeRegistry.addRecipes(RecipeRegistry.java:171) [RecipeRegistry.class:?]
	at mezz.jei.recipes.RecipeRegistry.<init>(RecipeRegistry.java:98) [RecipeRegistry.class:?]
	at mezz.jei.startup.ModRegistry.createRecipeRegistry(ModRegistry.java:335) [ModRegistry.class:?]
	at mezz.jei.startup.JeiStarter.start(JeiStarter.java:81) [JeiStarter.class:?]
	at mezz.jei.startup.ProxyCommonClient.loadComplete(ProxyCommonClient.java:136) [ProxyCommonClient.class:?]
	at mezz.jei.JustEnoughItems.loadComplete(JustEnoughItems.java:55) [JustEnoughItems.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_51]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_51]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_51]
	at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_51]
        ...
```