### PR TITLE
Put honey bucket into forge:items/buckets/honey tag

### DIFF
--- a/src/main/resources/data/forge/tags/items/buckets/honey.json
+++ b/src/main/resources/data/forge/tags/items/buckets/honey.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "cyclic:honey_bucket",
+      "required": true
+    }
+  ]
+}


### PR DESCRIPTION
The Bumblezone, Productive Bees and Create are all putting Honey Buckets into forge:items/buckets/honey tag so that we can do better mod compatibility with honey buckets. So this PR is to put Cyclic's honey bucket into the same tag for better compat. Here's our tags:

https://github.com/TelepathicGrunt/Bumblezone/blob/1.16/src/main/resources/data/forge/tags/items/buckets/honey.json
https://github.com/Creators-of-Create/Create/blob/1abc3a8bf9e63ab22823fe78bfa3c6d2f370b19b/src/main/java/com/simibubi/create/AllFluids.java#L50
https://github.com/JDKDigital/productive-bees/blob/dev-1.17.1/src/main/resources/data/forge/tags/items/buckets/honey.json