### PR TITLE
Increased performance, compile time optimisations, reduction in cyclomatic complexity and removal of redundant checks

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
+++ b/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
@@ -16,11 +16,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
@@ -45,6 +47,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 
 public abstract class TileEntityBase extends TileEntity implements IInventory {
@@ -249,36 +252,56 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
   }
 
   public void tryExtract(IItemHandler myself, Direction extractSide, int qty, ItemStackHandler nullableFilter) {
-    if (extractSide == null) {
+    if (qty <= 0)
       return;
-    }
-    if (extractSide == null || !myself.getStackInSlot(0).isEmpty()) {
+
+    if (extractSide == null)
       return;
-    }
-    BlockPos posTarget = pos.offset(extractSide);
-    TileEntity tile = world.getTileEntity(posTarget);
-    if (tile != null) {
-      IItemHandler itemHandlerFrom = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, extractSide.getOpposite()).orElse(null);
-      //
-      ItemStack itemTarget;
-      if (itemHandlerFrom != null) {
-        //ok go
-        for (int i = 0; i < itemHandlerFrom.getSlots(); i++) {
-          itemTarget = itemHandlerFrom.extractItem(i, qty, true);
-          if (itemTarget.isEmpty()) {
-            continue;
-          }
-          // and then pull 
-          if (nullableFilter != null &&
-              !FilterCardItem.filterAllowsExtract(nullableFilter.getStackInSlot(0), itemTarget)) {
-            continue;
-          }
-          itemTarget = itemHandlerFrom.extractItem(i, qty, false);
-          ItemStack result = myself.insertItem(0, itemTarget.copy(), false);
-          itemTarget.setCount(result.getCount());
-          return;
-        }
+
+    final BlockPos posTarget = pos.offset(extractSide);
+    final TileEntity tile = world.getTileEntity(posTarget);
+    if (tile == null)
+      return;
+
+    final IItemHandler itemHandlerFrom = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, extractSide.getOpposite()).orElse(null);
+    if (itemHandlerFrom == null)
+      return;
+
+    final ItemStack stackInSlot = myself.getStackInSlot(0);
+    if (!stackInSlot.isEmpty())
+      return;
+
+    final int slotLimit = Math.min(myself.getSlotLimit(0), qty);
+
+    for (int slot = 0; slot < itemHandlerFrom.getSlots(); slot++) {
+      final ItemStack itemStackToExtract = itemHandlerFrom.getStackInSlot(slot);
+      if (itemStackToExtract.isEmpty())
+        continue;
+
+      if (nullableFilter != null &&
+              !FilterCardItem.filterAllowsExtract(nullableFilter.getStackInSlot(0), itemStackToExtract))
+        continue;
+
+      //find the theoretical maximum we can extract
+      int limit = Math.min(itemStackToExtract.getCount(), itemStackToExtract.getMaxStackSize());
+      limit = Math.min(limit, slotLimit);
+
+      //check there is room to extract more
+      if (limit <= 0)
+        return;
+
+      final ItemStack extractedItemStack = itemHandlerFrom.extractItem(slot, limit, false);
+      ItemStack remainderItemStack = myself.insertItem(0, extractedItemStack, false);
+
+      //sanity check
+      if (!remainderItemStack.isEmpty()) {
+        ModCyclic.LOGGER.error("Incorrect number of items extracted, have to re-insert " + remainderItemStack);
+        remainderItemStack = itemHandlerFrom.insertItem(slot, remainderItemStack, false);
+        if (!remainderItemStack.isEmpty())
+          ModCyclic.LOGGER.error("Incorrect number of items extracted and now unable to re-insert, " + remainderItemStack + " have been lost");
       }
+
+      return;
     }
   }
 
@@ -287,41 +310,77 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
   }
 
   public boolean moveItems(Direction myFacingDir, BlockPos posTarget, int max, IItemHandler handlerHere, int theslot) {
-    if (this.world.isRemote()) {
+    if (max <= 0)
       return false;
-    }
-    if (handlerHere == null) {
+
+    if (this.world.isRemote())
       return false;
-    }
-    Direction themFacingMe = myFacingDir.getOpposite();
-    TileEntity tileTarget = world.getTileEntity(posTarget);
-    if (tileTarget == null) {
+
+    if (handlerHere == null)
       return false;
-    }
-    IItemHandler handlerOutput = tileTarget.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, themFacingMe).orElse(null);
-    if (handlerOutput == null) {
+
+    final Direction themFacingMe = myFacingDir.getOpposite();
+    final TileEntity tileTarget = world.getTileEntity(posTarget);
+    if (tileTarget == null)
       return false;
-    }
-    if (handlerHere != null && handlerOutput != null) {
-      //first simulate 
-      ItemStack drain = handlerHere.extractItem(theslot, max, true); // handlerHere.getStackInSlot(theslot).copy();
-      int sizeStarted = drain.getCount();
-      if (!drain.isEmpty()) {
-        //now push it into output, but find out what was ACTUALLY taken
-        for (int slot = 0; slot < handlerOutput.getSlots(); slot++) {
-          drain = handlerOutput.insertItem(slot, drain, false);
-          if (drain.isEmpty()) {
-            break; //done draining
-          }
-        }
+
+    final IItemHandler handlerOutput = tileTarget.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, themFacingMe).orElse(null);
+    if (handlerOutput == null)
+      return false;
+
+    //first get the original ItemStack as creating new ones is expensive
+    final ItemStack originalItemStack = handlerHere.getStackInSlot(theslot);
+    if (originalItemStack.isEmpty())
+      return false;
+
+    final int maxStackSize = originalItemStack.getMaxStackSize();
+    final int originalCount = originalItemStack.getCount();
+    int remainingItemCount = originalCount;
+
+    //lazily create an ItemStack for inserting and re-use it for future inserts
+    final Supplier<ItemStack> itemStackToInsert = originalItemStack::copy;
+
+    //attempt to push into output
+    for (int slot = 0; slot < handlerOutput.getSlots(); slot++) {
+      //find the theoretical maximum we can insert
+      int limit = Math.min(remainingItemCount, maxStackSize);
+      limit = Math.min(limit, handlerOutput.getSlotLimit(slot));
+
+      //reduce limit by amount already in the output slot
+      final ItemStack stackInOutputSlot = handlerOutput.getStackInSlot(slot);
+      if (!stackInOutputSlot.isEmpty()) {
+        //if the output slot is not compatible then skip this slot
+        if (!ItemHandlerHelper.canItemStacksStack(originalItemStack, stackInOutputSlot))
+          continue;
+        limit -= stackInOutputSlot.getCount();
       }
-      int sizeAfter = sizeStarted - drain.getCount();
-      if (sizeAfter > 0) {
-        handlerHere.extractItem(theslot, sizeAfter, false);
-      }
-      return sizeAfter > 0;
+      limit = Math.min(limit, max);
+
+      //skip this output slot if we cannot insert more
+      if (limit <= 0)
+        continue;
+
+      itemStackToInsert.get().setCount(limit);
+
+      //only perform an insert (even simulated) if required as it creates at least one new ItemStack in the process
+      final ItemStack remainderItemStack = handlerOutput.insertItem(slot, itemStackToInsert.get(), false);
+      remainingItemCount -= (limit - remainderItemStack.getCount());
+      if (remainingItemCount <= 0)
+        break;
     }
-    return false;
+
+    final int insertedItemCount = originalCount - remainingItemCount;
+    final boolean didInsertItems = insertedItemCount > 0;
+    if (didInsertItems) {
+      //only perform an extraction if required as it creates a new ItemStack in the process
+      final ItemStack finalItemStack = handlerHere.extractItem(theslot, insertedItemCount, false);
+
+      //sanity check
+      final int finalItemCount = finalItemStack.getCount();
+      if (finalItemCount != remainingItemCount)
+        ModCyclic.LOGGER.error("Incorrect number of items moved, " + finalItemStack + " remaining not " + remainingItemCount);
+    }
+    return didInsertItems;
   }
 
   protected boolean moveEnergy(Direction myFacingDir, int quantity) {
@@ -329,40 +388,44 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
   }
 
   protected boolean moveEnergy(Direction myFacingDir, BlockPos posTarget, int quantity) {
-    if (this.world.isRemote) {
-      return false; //important to not desync cables
-    }
-    IEnergyStorage handlerHere = this.getCapability(CapabilityEnergy.ENERGY, myFacingDir).orElse(null);
-    if (handlerHere == null || handlerHere.getEnergyStored() == 0) {
+    if (quantity <= 0)
       return false;
-    }
+
+    if (this.world.isRemote)
+      return false; //important to not desync cables
+
+    IEnergyStorage handlerHere = this.getCapability(CapabilityEnergy.ENERGY, myFacingDir).orElse(null);
+    if (handlerHere == null)
+      return false;
+
     Direction themFacingMe = myFacingDir.getOpposite();
     TileEntity tileTarget = world.getTileEntity(posTarget);
-    if (tileTarget == null) {
+    if (tileTarget == null)
       return false;
-    }
     IEnergyStorage handlerOutput = tileTarget.getCapability(CapabilityEnergy.ENERGY, themFacingMe).orElse(null);
-    if (handlerOutput == null) {
+    if (handlerOutput == null)
       return false;
+
+    //first simulate
+    int drain = handlerHere.extractEnergy(quantity, true);
+    if (drain <= 0)
+      return false;
+
+    //now push it into output, but find out what was ACTUALLY taken
+    int filled = handlerOutput.receiveEnergy(drain, false);
+    if (filled <= 0)
+      return false;
+
+    //now actually drain that much from here
+    handlerHere.extractEnergy(filled, false);
+
+    if (tileTarget instanceof TileCableEnergy) {
+      // not so compatible with other fluid systems. it will do i guess
+      TileCableEnergy cable = (TileCableEnergy) tileTarget;
+      cable.updateIncomingEnergyFace(themFacingMe);
     }
-    if (handlerHere != null && handlerOutput != null
-        && handlerHere.canExtract() && handlerOutput.canReceive()) {
-      //first simulate
-      int drain = handlerHere.extractEnergy(quantity, true);
-      if (drain > 0) {
-        //now push it into output, but find out what was ACTUALLY taken
-        int filled = handlerOutput.receiveEnergy(drain, false);
-        //now actually drain that much from here
-        handlerHere.extractEnergy(filled, false);
-        if (filled > 0 && tileTarget instanceof TileCableEnergy) {
-          // not so compatible with other fluid systems. itl do i guess
-          TileCableEnergy cable = (TileCableEnergy) tileTarget;
-          cable.updateIncomingEnergyFace(themFacingMe);
-        }
-        return filled > 0;
-      }
-    }
-    return false;
+
+    return true;
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -113,7 +113,7 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
   @Override
   public void read(BlockState bs, CompoundNBT tag) {
     for (final Direction direction : Direction.values()) {
-      final String key = UtilDirection.energyNBTKeyMapping.get(direction);
+      final String key = direction.getString() + "_incenergy";
       mapIncomingEnergy.put(direction, tag.getInt(key));
     }
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
@@ -123,7 +123,7 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
   @Override
   public CompoundNBT write(CompoundNBT tag) {
     for (final Direction direction : Direction.values()) {
-      final String key = UtilDirection.energyNBTKeyMapping.get(direction);
+      final String key = direction.getString() + "_incenergy";
       tag.putInt(key, mapIncomingEnergy.get(direction));
     }
     tag.put(NBTENERGY, energy.serializeNBT());

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -70,10 +70,10 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
       return;
 
     final int energyReceived = energy.receiveEnergy(energyToExtract, false);
-    if (energyReceived <= 0 )
+    if (energyReceived <= 0)
       return;
 
-    final int energyExtracted = itemHandlerFrom.extractEnergy(energyToExtract, false);
+    final int energyExtracted = itemHandlerFrom.extractEnergy(energyReceived, false);
 
     //sanity check
     if (energyExtracted != energyReceived)

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -112,9 +112,8 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
 
   @Override
   public void read(BlockState bs, CompoundNBT tag) {
-    for (final Direction direction : Direction.values()) {
-      final String key = direction.getString() + "_incenergy";
-      mapIncomingEnergy.put(direction, tag.getInt(key));
+    for (Direction f : Direction.values()) {
+      mapIncomingEnergy.put(f, tag.getInt(f.getString() + "_incenergy"));
     }
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     super.read(bs, tag);
@@ -122,9 +121,8 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
 
   @Override
   public CompoundNBT write(CompoundNBT tag) {
-    for (final Direction direction : Direction.values()) {
-      final String key = direction.getString() + "_incenergy";
-      tag.putInt(key, mapIncomingEnergy.get(direction));
+    for (Direction f : Direction.values()) {
+      tag.putInt(f.getString() + "_incenergy", mapIncomingEnergy.get(f));
     }
     tag.put(NBTENERGY, energy.serializeNBT());
     return super.write(tag);

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -114,11 +114,11 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
 
     //handle source blocks
     final FluidState fluidState = world.getFluidState(target);
-    if (!fluidState.isSource())
+    final Fluid fluid = fluidState.getFluid();
+    if (!fluid.isSource(fluidState))
       return;
 
-    //get the type of fluid before trying to change the block to air
-    final Fluid fluid = fluidState.getFluid();
+    //remove the fluid source block
     if (!world.setBlockState(target, Blocks.AIR.getDefaultState()))
       return;
 

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -77,12 +77,12 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
 
     final BlockPos target = this.pos.offset(extractSide);
     final Direction incomingSide = extractSide.getOpposite();
+
+    //when draining from a tank (instead of a source/waterlogged block) check the filter
     final IFluidHandler tank = UtilFluid.getTank(world, target, incomingSide);
-    if (tank == null)
-      return;
-    else if (tank.getTanks() <= 0)
-      return;
-    else if (!FilterCardItem.filterAllowsExtract(filter.getStackInSlot(0), tank.getFluidInTank(0)))
+    if (tank != null
+            && tank.getTanks() > 0
+            && !FilterCardItem.filterAllowsExtract(filter.getStackInSlot(0), tank.getFluidInTank(0)))
       return;
 
     //first try standard fluid transfer

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -161,7 +161,7 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
   public void read(BlockState bs, CompoundNBT tag) {
     filter.deserializeNBT(tag.getCompound("filter"));
     for (final Direction direction : Direction.values()) {
-      final String key = UtilDirection.fluidNBTKeyMapping.get(direction);
+      final String key = "fluid" + direction.getString();
       final CompoundNBT fluidTag = tag.getCompound(key);
       if (!fluidTag.isEmpty()) {
         final FluidTankBase fluidHandler = flow.get(direction).orElse(null);
@@ -179,7 +179,7 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
       final FluidTankBase fluidHandler = flow.get(direction).orElse(null);
       if (fluidHandler != null)
         fluidHandler.writeToNBT(fluidTag);
-      final String key = UtilDirection.fluidNBTKeyMapping.get(direction);
+      final String key = "fluid" + direction.getString();
       tag.put(key, fluidTag);
     }
     return super.write(tag);

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -160,12 +160,11 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
   @Override
   public void read(BlockState bs, CompoundNBT tag) {
     filter.deserializeNBT(tag.getCompound("filter"));
-    for (final Direction direction : Direction.values()) {
-      final String key = "fluid" + direction.getString();
-      final CompoundNBT fluidTag = tag.getCompound(key);
-      if (!fluidTag.isEmpty()) {
-        final FluidTankBase fluidHandler = flow.get(direction).orElse(null);
-        fluidHandler.readFromNBT(fluidTag);
+    FluidTankBase fluidh;
+    for (Direction dir : Direction.values()) {
+      fluidh = flow.get(dir).orElse(null);
+      if (tag.contains("fluid" + dir.toString())) {
+        fluidh.readFromNBT(tag.getCompound("fluid" + dir.toString()));
       }
     }
     super.read(bs, tag);
@@ -174,13 +173,14 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
   @Override
   public CompoundNBT write(CompoundNBT tag) {
     tag.put("filter", filter.serializeNBT());
-    for (final Direction direction : Direction.values()) {
-      final CompoundNBT fluidTag = new CompoundNBT();
-      final FluidTankBase fluidHandler = flow.get(direction).orElse(null);
-      if (fluidHandler != null)
-        fluidHandler.writeToNBT(fluidTag);
-      final String key = "fluid" + direction.getString();
-      tag.put(key, fluidTag);
+    FluidTankBase fluidh;
+    for (Direction dir : Direction.values()) {
+      fluidh = flow.get(dir).orElse(null);
+      CompoundNBT fluidtag = new CompoundNBT();
+      if (fluidh != null) {
+        fluidh.writeToNBT(fluidtag);
+      }
+      tag.put("fluid" + dir.toString(), fluidtag);
     }
     return super.write(tag);
   }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -103,7 +103,7 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
     extractQty = tag.getInt("extractCount");
     for (final Direction direction : Direction.values()) {
       flow.get(direction).ifPresent(itemHandler -> {
-        final String key = UtilDirection.itemNBTKeyMapping.get(direction);
+        final String key = "item" + direction.getString();
         final CompoundNBT itemTag = tag.getCompound(key);
         ((INBTSerializable<CompoundNBT>) itemHandler).deserializeNBT(itemTag);
       });
@@ -120,7 +120,7 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
     for (final Direction direction : Direction.values()) {
       flow.get(direction).ifPresent(itemHandler -> {
         final CompoundNBT itemTag = ((INBTSerializable<CompoundNBT>) itemHandler).serializeNBT();
-        final String key = UtilDirection.itemNBTKeyMapping.get(direction);
+        final String key = "item" + direction.getString();
         tag.put(key, itemTag);
       });
     }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -101,11 +101,12 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
   @Override
   public void read(BlockState bs, CompoundNBT tag) {
     extractQty = tag.getInt("extractCount");
-    for (final Direction direction : Direction.values()) {
-      flow.get(direction).ifPresent(itemHandler -> {
-        final String key = "item" + direction.getString();
-        final CompoundNBT itemTag = tag.getCompound(key);
-        ((INBTSerializable<CompoundNBT>) itemHandler).deserializeNBT(itemTag);
+    LazyOptional<IItemHandler> item;
+    for (Direction f : Direction.values()) {
+      item = flow.get(f);
+      item.ifPresent(h -> {
+        CompoundNBT itemTag = tag.getCompound("item" + f.toString());
+        ((INBTSerializable<CompoundNBT>) h).deserializeNBT(itemTag);
       });
     }
     filter.deserializeNBT(tag.getCompound("filter"));
@@ -117,11 +118,12 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
   public CompoundNBT write(CompoundNBT tag) {
     tag.put("filter", filter.serializeNBT());
     tag.putInt("extractCount", extractQty);
-    for (final Direction direction : Direction.values()) {
-      flow.get(direction).ifPresent(itemHandler -> {
-        final CompoundNBT itemTag = ((INBTSerializable<CompoundNBT>) itemHandler).serializeNBT();
-        final String key = "item" + direction.getString();
-        tag.put(key, itemTag);
+    LazyOptional<IItemHandler> item;
+    for (Direction f : Direction.values()) {
+      item = flow.get(f);
+      item.ifPresent(h -> {
+        CompoundNBT compound = ((INBTSerializable<CompoundNBT>) h).serializeNBT();
+        tag.put("item" + f.toString(), compound);
       });
     }
     return super.write(tag);

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -6,11 +6,8 @@ import com.lothrazar.cyclic.block.cable.CableBase;
 import com.lothrazar.cyclic.block.cable.EnumConnectType;
 import com.lothrazar.cyclic.registry.ItemRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import com.lothrazar.cyclic.util.UtilDirection;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -18,6 +15,7 @@ import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.state.EnumProperty;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
@@ -53,16 +51,13 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
     return new ItemStackHandler(1);
   }
 
-  List<Integer> rawList = IntStream.rangeClosed(
-      0,
-      5).boxed().collect(Collectors.toList());
-
   @Override
   public void tick() {
-    for (Direction extractSide : Direction.values()) {
-      EnumConnectType connection = this.getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(extractSide));
+    for (final Direction extractSide : Direction.values()) {
+      final EnumProperty<EnumConnectType> extractFace = CableBase.FACING_TO_PROPERTY_MAP.get(extractSide);
+      final EnumConnectType connection = this.getBlockState().get(extractFace);
       if (connection.isExtraction()) {
-        IItemHandler sideHandler = flow.get(extractSide).orElse(null);
+        final IItemHandler sideHandler = flow.get(extractSide).orElse(null);
         tryExtract(sideHandler, extractSide, extractQty, filter);
       }
     }
@@ -70,27 +65,25 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
   }
 
   private void normalFlow() {
-    IItemHandler sideHandler;
-    Direction outgoingSide;
-    for (Direction incomingSide : Direction.values()) {
-      sideHandler = flow.get(incomingSide).orElse(null);
-      //thise items came from that
-      Collections.shuffle(rawList);
-      boolean validAdjacent = false;
-      for (Integer i : rawList) {
-        outgoingSide = Direction.values()[i];
-        if (outgoingSide == incomingSide) {
+    incomingSideLoop: for (final Direction incomingSide : Direction.values()) {
+      //in all cases sideHandler is required
+      final IItemHandler sideHandler = flow.get(incomingSide).orElse(null);
+
+      for (final Direction outgoingSide : UtilDirection.inDifferingOrder.next()) {
+        if (outgoingSide == incomingSide)
           continue;
-        }
-        EnumConnectType connection = this.getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide));
-        if (connection.isExtraction() || connection.isBlocked()) {
+
+        final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
+        final EnumConnectType outgoingConnection = this.getBlockState().get(outgoingFace);
+        if (outgoingConnection.isExtraction() || outgoingConnection.isBlocked())
           continue;
-        }
-        validAdjacent = validAdjacent || this.moveItems(outgoingSide, 64, sideHandler);
+
+        if (this.moveItems(outgoingSide, FLOW_QTY, sideHandler))
+          continue incomingSideLoop; //if items have been moved then change side
       }
-      if (!validAdjacent) {
-        this.moveItems(incomingSide, FLOW_QTY, sideHandler);
-      }
+
+      //if no items have been moved then move items in from adjacent
+      this.moveItems(incomingSide, FLOW_QTY, sideHandler);
     }
   }
 
@@ -108,12 +101,11 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
   @Override
   public void read(BlockState bs, CompoundNBT tag) {
     extractQty = tag.getInt("extractCount");
-    LazyOptional<IItemHandler> item;
-    for (Direction f : Direction.values()) {
-      item = flow.get(f);
-      item.ifPresent(h -> {
-        CompoundNBT itemTag = tag.getCompound("item" + f.toString());
-        ((INBTSerializable<CompoundNBT>) h).deserializeNBT(itemTag);
+    for (final Direction direction : Direction.values()) {
+      flow.get(direction).ifPresent(itemHandler -> {
+        final String key = UtilDirection.itemNBTKeyMapping.get(direction);
+        final CompoundNBT itemTag = tag.getCompound(key);
+        ((INBTSerializable<CompoundNBT>) itemHandler).deserializeNBT(itemTag);
       });
     }
     filter.deserializeNBT(tag.getCompound("filter"));
@@ -125,12 +117,11 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
   public CompoundNBT write(CompoundNBT tag) {
     tag.put("filter", filter.serializeNBT());
     tag.putInt("extractCount", extractQty);
-    LazyOptional<IItemHandler> item;
-    for (Direction f : Direction.values()) {
-      item = flow.get(f);
-      item.ifPresent(h -> {
-        CompoundNBT compound = ((INBTSerializable<CompoundNBT>) h).serializeNBT();
-        tag.put("item" + f.toString(), compound);
+    for (final Direction direction : Direction.values()) {
+      flow.get(direction).ifPresent(itemHandler -> {
+        final CompoundNBT itemTag = ((INBTSerializable<CompoundNBT>) itemHandler).serializeNBT();
+        final String key = UtilDirection.itemNBTKeyMapping.get(direction);
+        tag.put(key, itemTag);
       });
     }
     return super.write(tag);

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -6,9 +6,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import net.minecraft.util.Direction;
 
 public class UtilDirection {
@@ -30,16 +27,4 @@ public class UtilDirection {
     public static final Iterator<List<Direction>> inDifferingOrder = Iterables
             .cycle(permutateDirections(Arrays.asList(Direction.values()), 0))
             .iterator();
-
-    private static final Stream<Direction> directionStream = Arrays.stream(Direction.values());
-
-    public static final Map<Direction, String> energyNBTKeyMapping = directionStream
-            .collect(Collectors.toMap(direction -> direction, direction -> direction.getString() + "_incenergy"));
-
-    public static final Map<Direction, String> fluidNBTKeyMapping = directionStream
-            .collect(Collectors.toMap(direction -> direction, direction -> "fluid" + direction.getString()));
-
-    public static final Map<Direction, String> itemNBTKeyMapping = directionStream
-            .collect(Collectors.toMap(direction -> direction, direction -> "item" + direction.getString()));
-
 }

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -1,0 +1,45 @@
+package com.lothrazar.cyclic.util;
+
+import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.minecraft.util.Direction;
+
+public class UtilDirection {
+
+    //determine all permutations of direction order at compile time and cycle through them at runtime
+    //the alternative of using a random order is costly and left to chance
+    private static List<List<Direction>> permutateDirections(final List<Direction> list, int pos) {
+        final List<List<Direction>> results = new ArrayList<>();
+        for (int i = pos; i < list.size(); i++) {
+            Collections.swap(list, i, pos);
+            results.addAll(permutateDirections(list, pos + 1));
+            Collections.swap(list, pos, i);
+        }
+        if (pos == list.size() - 1)
+            results.add(new ArrayList<>(list));
+        return results;
+    }
+
+    public static final Iterator<List<Direction>> inDifferingOrder = Iterables
+            .cycle(permutateDirections(Arrays.asList(Direction.values()), 0))
+            .iterator();
+
+    private static final Stream<Direction> directionStream = Arrays.stream(Direction.values());
+
+    public static final Map<Direction, String> energyNBTKeyMapping = directionStream
+            .collect(Collectors.toMap(direction -> direction, direction -> direction.getString() + "_incenergy"));
+
+    public static final Map<Direction, String> fluidNBTKeyMapping = directionStream
+            .collect(Collectors.toMap(direction -> direction, direction -> "fluid" + direction.getString()));
+
+    public static final Map<Direction, String> itemNBTKeyMapping = directionStream
+            .collect(Collectors.toMap(direction -> direction, direction -> "item" + direction.getString()));
+
+}

--- a/src/main/java/com/lothrazar/cyclic/util/UtilFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilFluid.java
@@ -117,10 +117,6 @@ public class UtilFluid {
     final FluidStack drained = tankFrom.drain(filledAmount, FluidAction.EXECUTE);
     final int drainedAmount = drained.getAmount();
 
-    //sanity check
-    if (drainedAmount != filledAmount)
-      ModCyclic.LOGGER.error("Incorrect amount of fluid transferred, filled " + filledAmount + " drained " + drainedAmount);
-
     return true;
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/util/UtilFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilFluid.java
@@ -13,6 +13,7 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -35,13 +36,10 @@ public class UtilFluid {
    * @return
    */
   public static TextureAtlasSprite getBaseFluidTexture(Fluid fluid, FluidType type) {
-    ResourceLocation spriteLocation;
-    if (type == FluidType.STILL) {
-      spriteLocation = fluid.getAttributes().getStillTexture();
-    }
-    else {
-      spriteLocation = fluid.getAttributes().getFlowingTexture();
-    }
+    final FluidAttributes fluidAttributes = fluid.getAttributes();
+    final ResourceLocation spriteLocation = (type == FluidType.STILL)
+            ? fluidAttributes.getStillTexture()
+            : fluidAttributes.getFlowingTexture();
     return getSprite(spriteLocation);
   }
 
@@ -50,30 +48,25 @@ public class UtilFluid {
   }
 
   public static Model3D getFluidModel(FluidStack fluid, int stage) {
-    if (CACHED_FLUIDS.containsKey(fluid) && CACHED_FLUIDS.get(fluid).containsKey(stage)) {
-      return CACHED_FLUIDS.get(fluid).get(stage);
-    }
-    Model3D model = new Model3D();
+    final Int2ObjectMap<Model3D> fluidCache = CACHED_FLUIDS
+            .computeIfAbsent(fluid, fluidStack -> new Int2ObjectOpenHashMap<>());
+    Model3D model = fluidCache.get(stage);
+    if (model != null)
+      return model;
+
+    model = new Model3D();
     model.setTexture(FluidRenderMap.getFluidTexture(fluid, FluidType.STILL));
     if (fluid.getFluid().getAttributes().getStillTexture(fluid) != null) {
       double sideSpacing = 0.00625;
       double belowSpacing = 0.0625 / 4;
-      double topSpacing = belowSpacing;
       model.minX = sideSpacing;
       model.minY = belowSpacing;
       model.minZ = sideSpacing;
       model.maxX = 1 - sideSpacing;
-      model.maxY = 1 - topSpacing;
+      model.maxY = 1 - belowSpacing;
       model.maxZ = 1 - sideSpacing;
     }
-    if (CACHED_FLUIDS.containsKey(fluid)) {
-      CACHED_FLUIDS.get(fluid).put(stage, model);
-    }
-    else {
-      Int2ObjectMap<Model3D> map = new Int2ObjectOpenHashMap<>();
-      map.put(stage, model);
-      CACHED_FLUIDS.put(fluid, map);
-    }
+    fluidCache.put(stage, model);
     return model;
   }
 
@@ -82,15 +75,13 @@ public class UtilFluid {
   }
 
   public static float getScale(int stored, int capacity, boolean empty) {
-    float targetScale = (float) stored / capacity;
-    return targetScale;
+    return (float) stored / capacity;
   }
 
   public static IFluidHandler getTank(World world, BlockPos pos, Direction side) {
-    TileEntity tile = world.getTileEntity(pos);
-    if (tile == null) {
+    final TileEntity tile = world.getTileEntity(pos);
+    if (tile == null)
       return null;
-    }
     return tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY).orElse(null);
   }
 
@@ -101,7 +92,7 @@ public class UtilFluid {
     if (tankFrom == null)
       return false;
 
-    IFluidHandler fluidTo = FluidUtil.getFluidHandler(world, posSide, sideOpp).orElse(null);
+    final IFluidHandler fluidTo = FluidUtil.getFluidHandler(world, posSide, sideOpp).orElse(null);
     if (fluidTo == null)
       return false;
 
@@ -116,6 +107,10 @@ public class UtilFluid {
 
     final FluidStack drained = tankFrom.drain(filledAmount, FluidAction.EXECUTE);
     final int drainedAmount = drained.getAmount();
+
+    //sanity check
+    if (filledAmount != drainedAmount)
+      ModCyclic.LOGGER.error("Imbalance filling fluids, filled " + filledAmount + " drained " + drainedAmount);
 
     return true;
   }


### PR DESCRIPTION
Had some performance issues when using Cyclic at scale as part of a SkyFactory One server, so have gone through the hot spots causing the issues and improved performance, added compile-time optimisations, reduced the cyclomatic complexity and removed some redundant checks.
Have been trying out the changes and removing anything that doesn't make a difference.
The biggest changes are avoiding the generation of new ItemStacks where possible for item cables and avoiding random where possible (whilst still achieving the same desired result).