### PR TITLE
Implement different directions as non-random (yet unpredictable) across entire code base and move random direction getter to utility class

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
+++ b/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
@@ -545,7 +545,7 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
   }
 
   public void exportEnergyAllSides() {
-    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
+    for (final Direction exportToSide : UtilDirection.getAllInDifferentOrder()) {
       moveEnergy(exportToSide, MENERGY / 2);
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
+++ b/src/main/java/com/lothrazar/cyclic/base/TileEntityBase.java
@@ -7,17 +7,15 @@ import com.lothrazar.cyclic.capability.CustomEnergyStorage;
 import com.lothrazar.cyclic.item.datacard.filter.FilterCardItem;
 import com.lothrazar.cyclic.net.PacketEnergySync;
 import com.lothrazar.cyclic.registry.PacketRegistry;
+import com.lothrazar.cyclic.util.UtilDirection;
 import com.lothrazar.cyclic.util.UtilEntity;
 import com.lothrazar.cyclic.util.UtilFakePlayer;
 import com.lothrazar.cyclic.util.UtilFluid;
 import com.lothrazar.cyclic.util.UtilItemStack;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
@@ -547,10 +545,7 @@ public abstract class TileEntityBase extends TileEntity implements IInventory {
   }
 
   public void exportEnergyAllSides() {
-    List<Integer> rawList = IntStream.rangeClosed(0, 5).boxed().collect(Collectors.toList());
-    Collections.shuffle(rawList);
-    for (Integer i : rawList) {
-      Direction exportToSide = Direction.values()[i];
+    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
       moveEnergy(exportToSide, MENERGY / 2);
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
+++ b/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
@@ -3,12 +3,9 @@ package com.lothrazar.cyclic.block.battery;
 import com.lothrazar.cyclic.base.TileEntityBase;
 import com.lothrazar.cyclic.capability.CustomEnergyStorage;
 import com.lothrazar.cyclic.registry.TileRegistry;
-import java.util.Collections;
+import com.lothrazar.cyclic.util.UtilDirection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -174,12 +171,8 @@ public class TileBattery extends TileEntityBase implements INamedContainerProvid
     return new ContainerBattery(i, world, pos, playerInventory, playerEntity);
   }
 
-  private List<Integer> rawList = IntStream.rangeClosed(0, 5).boxed().collect(Collectors.toList());
-
   private void tickCableFlow() {
-    Collections.shuffle(rawList);
-    for (Integer i : rawList) {
-      Direction exportToSide = Direction.values()[i];
+    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         moveEnergy(exportToSide, MAX / 4);
       }

--- a/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
+++ b/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
@@ -172,7 +172,7 @@ public class TileBattery extends TileEntityBase implements INamedContainerProvid
   }
 
   private void tickCableFlow() {
-    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
+    for (final Direction exportToSide : UtilDirection.getAllInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         moveEnergy(exportToSide, MAX / 4);
       }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -88,7 +88,7 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
   }
 
   private void tickCableFlow() {
-    for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
+    for (final Direction outgoingSide : UtilDirection.getAllInDifferentOrder()) {
       final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
       final EnumConnectType connection = this.getBlockState().get(outgoingFace);
       if (connection.isExtraction() || connection.isBlocked()) {

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -10,7 +10,6 @@ import com.lothrazar.cyclic.net.PacketEnergySync;
 import com.lothrazar.cyclic.registry.PacketRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
 import com.lothrazar.cyclic.util.UtilDirection;
-import java.util.List;
 import java.util.Map;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
@@ -89,8 +88,7 @@ public class TileCableEnergy extends TileEntityBase implements ITickableTileEnti
   }
 
   private void tickCableFlow() {
-    List<Direction> list = UtilDirection.getRandomSet(world.rand);
-    for (final Direction outgoingSide : list) {
+    for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
       final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
       final EnumConnectType connection = this.getBlockState().get(outgoingFace);
       if (connection.isExtraction() || connection.isBlocked()) {

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -11,7 +11,6 @@ import com.lothrazar.cyclic.registry.ItemRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
 import com.lothrazar.cyclic.util.UtilDirection;
 import com.lothrazar.cyclic.util.UtilFluid;
-import java.util.List;
 import java.util.Map;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -134,8 +133,7 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
   private void normalFlow() {
     for (Direction incomingSide : Direction.values()) {
       final IFluidHandler sideHandler = flow.get(incomingSide).orElse(null);
-      List<Direction> list = UtilDirection.getRandomSet(world.rand);
-      for (final Direction outgoingSide : list) {
+      for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
         if (outgoingSide == incomingSide) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -133,7 +133,7 @@ public class TileCableFluid extends TileEntityBase implements ITickableTileEntit
   private void normalFlow() {
     for (Direction incomingSide : Direction.values()) {
       final IFluidHandler sideHandler = flow.get(incomingSide).orElse(null);
-      for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
+      for (final Direction outgoingSide : UtilDirection.getAllInDifferentOrder()) {
         if (outgoingSide == incomingSide) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -7,7 +7,6 @@ import com.lothrazar.cyclic.block.cable.EnumConnectType;
 import com.lothrazar.cyclic.registry.ItemRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
 import com.lothrazar.cyclic.util.UtilDirection;
-import java.util.List;
 import java.util.Map;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -70,9 +69,7 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
     incomingSideLoop: for (final Direction incomingSide : Direction.values()) {
       //in all cases sideHandler is required
       final IItemHandler sideHandler = flow.get(incomingSide).orElse(null);
-      List<Direction> list = UtilDirection.getRandomSet(world.rand);
-      //we checked hasNext, so iterator wont hit a NoSuchElementException
-      for (final Direction outgoingSide : list) {
+      for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
         if (outgoingSide == incomingSide) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -69,7 +69,7 @@ public class TileCableItem extends TileEntityBase implements ITickableTileEntity
     incomingSideLoop: for (final Direction incomingSide : Direction.values()) {
       //in all cases sideHandler is required
       final IItemHandler sideHandler = flow.get(incomingSide).orElse(null);
-      for (final Direction outgoingSide : UtilDirection.getDirectionsInDifferentOrder()) {
+      for (final Direction outgoingSide : UtilDirection.getAllInDifferentOrder()) {
         if (outgoingSide == incomingSide) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
+++ b/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
@@ -88,7 +88,7 @@ public class TileBatteryInfinite extends TileEntityBase implements ITickableTile
   }
 
   private void tickCableFlow() {
-    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
+    for (final Direction exportToSide : UtilDirection.getAllInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         moveEnergy(exportToSide, MAX / 4);
       }

--- a/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
+++ b/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
@@ -3,12 +3,9 @@ package com.lothrazar.cyclic.block.creativebattery;
 import com.lothrazar.cyclic.base.TileEntityBase;
 import com.lothrazar.cyclic.capability.CustomEnergyStorage;
 import com.lothrazar.cyclic.registry.TileRegistry;
-import java.util.Collections;
+import com.lothrazar.cyclic.util.UtilDirection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
@@ -90,13 +87,8 @@ public class TileBatteryInfinite extends TileEntityBase implements ITickableTile
     this.tickCableFlow();
   }
 
-  private List<Integer> rawList = IntStream.rangeClosed(
-      0, 5).boxed().collect(Collectors.toList());
-
   private void tickCableFlow() {
-    Collections.shuffle(rawList);
-    for (Integer i : rawList) {
-      Direction exportToSide = Direction.values()[i];
+    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         moveEnergy(exportToSide, MAX / 4);
       }

--- a/src/main/java/com/lothrazar/cyclic/block/dice/BlockDice.java
+++ b/src/main/java/com/lothrazar/cyclic/block/dice/BlockDice.java
@@ -4,7 +4,6 @@ import com.lothrazar.cyclic.base.BlockBase;
 import com.lothrazar.cyclic.registry.SoundRegistry;
 import com.lothrazar.cyclic.util.UtilBlockstates;
 import com.lothrazar.cyclic.util.UtilSound;
-import java.util.Random;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.RenderType;
@@ -17,11 +16,9 @@ import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
-import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockDisplayReader;
@@ -87,16 +84,5 @@ public class BlockDice extends BlockBase {
       return ActionResultType.SUCCESS;
     }
     return super.onBlockActivated(state, world, pos, player, hand, result);
-  }
-
-  /**
-   * TODO: util
-   * 
-   * @param rand
-   * @return
-   */
-  public static Direction getRandom(Random rand) {
-    int index = MathHelper.nextInt(rand, 0, Direction.values().length - 1);
-    return Direction.values()[index];
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/dice/TileDice.java
+++ b/src/main/java/com/lothrazar/cyclic/block/dice/TileDice.java
@@ -2,6 +2,7 @@ package com.lothrazar.cyclic.block.dice;
 
 import com.lothrazar.cyclic.base.TileEntityBase;
 import com.lothrazar.cyclic.registry.TileRegistry;
+import com.lothrazar.cyclic.util.UtilDirection;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.state.properties.BlockStateProperties;
@@ -50,7 +51,7 @@ public class TileDice extends TileEntityBase implements ITickableTileEntity {
       //toggle block state
       if (this.timer % TICKS_PER_CHANGE == 0) {
         this.spinningIfZero = 0;
-        Direction fac = BlockDice.getRandom(world.rand);
+        Direction fac = UtilDirection.getRandom(world.rand);
         BlockState stateold = world.getBlockState(pos);
         BlockState newstate = stateold.with(BlockStateProperties.FACING, fac);
         world.setBlockState(pos, newstate);
@@ -70,7 +71,7 @@ public class TileDice extends TileEntityBase implements ITickableTileEntity {
     //        //toggle block state
     //        if (this.timer % TICKS_PER_CHANGE == 0) {
     //          this.spinningIfZero = 0;
-    //          EnumFacing fac = BlockDice.getRandom(world.rand);
+    //          EnumFacing fac = UtilDirection.getRandom(world.rand);
     //          IBlockState stateold = world.getBlockState(pos);
     //          IBlockState newstate = stateold.withProperty(BlockDice.PROPERTYFACING, fac);
     //          world.setBlockState(pos, newstate);

--- a/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
+++ b/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
@@ -3,13 +3,11 @@ package com.lothrazar.cyclic.block.tankcask;
 import com.lothrazar.cyclic.base.FluidTankBase;
 import com.lothrazar.cyclic.base.TileEntityBase;
 import com.lothrazar.cyclic.registry.TileRegistry;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+
+import com.lothrazar.cyclic.util.UtilDirection;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.ITickableTileEntity;
@@ -148,14 +146,8 @@ public class TileCask extends TileEntityBase implements ITickableTileEntity {
     }
   }
 
-  private List<Integer> rawList = IntStream.rangeClosed(
-      0,
-      5).boxed().collect(Collectors.toList());
-
   private void tickCableFlow() {
-    Collections.shuffle(rawList);
-    for (Integer i : rawList) {
-      Direction exportToSide = Direction.values()[i];
+    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         this.moveFluids(exportToSide, pos.offset(exportToSide), TRANSFER_FLUID_PER_TICK / 4, tank);
       }

--- a/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
+++ b/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
@@ -147,7 +147,7 @@ public class TileCask extends TileEntityBase implements ITickableTileEntity {
   }
 
   private void tickCableFlow() {
-    for (final Direction exportToSide : UtilDirection.getDirectionsInDifferentOrder()) {
+    for (final Direction exportToSide : UtilDirection.getAllInDifferentOrder()) {
       if (this.poweredSides.get(exportToSide)) {
         this.moveFluids(exportToSide, pos.offset(exportToSide), TRANSFER_FLUID_PER_TICK / 4, tank);
       }

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import net.minecraft.util.Direction;
+import net.minecraft.util.math.MathHelper;
 
 public class UtilDirection {
 
@@ -24,10 +25,17 @@ public class UtilDirection {
     return results;
   }
 
-  public static List<Direction> getRandomSet(Random rand) {
-    int idx = rand.nextInt(DIRECTIONS_DIFFERENT_ORDER.size() - 1);
-    return DIRECTIONS_DIFFERENT_ORDER.get(idx);
+  public static final List<List<Direction>> DIRECTIONS_DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
+  public static final int DIRECTIONS_DIFFERENT_ORDER_SIZE = DIRECTIONS_DIFFERENT_ORDER.size();
+  public static int directionsDifferentOrderIndex = -1;
+
+  public static List<Direction> getDirectionsInDifferentOrder() {
+    directionsDifferentOrderIndex = directionsDifferentOrderIndex + 1 % DIRECTIONS_DIFFERENT_ORDER_SIZE;
+    return DIRECTIONS_DIFFERENT_ORDER.get(directionsDifferentOrderIndex);
   }
 
-  public static final List<List<Direction>> DIRECTIONS_DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
+  public static Direction getRandom(final Random rand) {
+    int index = MathHelper.nextInt(rand, 0, Direction.values().length - 1);
+    return Direction.values()[index];
+  }
 }

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -25,13 +25,13 @@ public class UtilDirection {
     return results;
   }
 
-  public static final List<List<Direction>> DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
-  public static int differentOrderIndex = -1;
+  public static final List<List<Direction>> ALL_DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
+  public static int allDifferentOrderIndex = -1;
 
   public static List<Direction> getAllInDifferentOrder() {
-    differentOrderIndex++;
-    differentOrderIndex %= DIFFERENT_ORDER.size();
-    return DIFFERENT_ORDER.get(differentOrderIndex);
+    allDifferentOrderIndex++;
+    allDifferentOrderIndex %= ALL_DIFFERENT_ORDER.size();
+    return ALL_DIFFERENT_ORDER.get(allDifferentOrderIndex);
   }
 
   public static Direction getRandom(final Random rand) {

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -25,13 +25,13 @@ public class UtilDirection {
     return results;
   }
 
-  public static final List<List<Direction>> DIRECTIONS_DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
+  public static final List<List<Direction>> DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
   public static int differentOrderIndex = -1;
 
-  public static List<Direction> getDirectionsInDifferentOrder() {
+  public static List<Direction> getAllInDifferentOrder() {
     differentOrderIndex++;
-    differentOrderIndex %= DIRECTIONS_DIFFERENT_ORDER.size();
-    return DIRECTIONS_DIFFERENT_ORDER.get(differentOrderIndex);
+    differentOrderIndex %= DIFFERENT_ORDER.size();
+    return DIFFERENT_ORDER.get(differentOrderIndex);
   }
 
   public static Direction getRandom(final Random rand) {

--- a/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
+++ b/src/main/java/com/lothrazar/cyclic/util/UtilDirection.java
@@ -26,12 +26,12 @@ public class UtilDirection {
   }
 
   public static final List<List<Direction>> DIRECTIONS_DIFFERENT_ORDER = permutateDirections(Arrays.asList(Direction.values()), 0);
-  public static final int DIRECTIONS_DIFFERENT_ORDER_SIZE = DIRECTIONS_DIFFERENT_ORDER.size();
-  public static int directionsDifferentOrderIndex = -1;
+  public static int differentOrderIndex = -1;
 
   public static List<Direction> getDirectionsInDifferentOrder() {
-    directionsDifferentOrderIndex = directionsDifferentOrderIndex + 1 % DIRECTIONS_DIFFERENT_ORDER_SIZE;
-    return DIRECTIONS_DIFFERENT_ORDER.get(directionsDifferentOrderIndex);
+    differentOrderIndex++;
+    differentOrderIndex %= DIRECTIONS_DIFFERENT_ORDER.size();
+    return DIRECTIONS_DIFFERENT_ORDER.get(differentOrderIndex);
   }
 
   public static Direction getRandom(final Random rand) {


### PR DESCRIPTION
Changed from an iterator to explicit iteration achieving the same and removing random.
Used this implementation across the entire code base.
Moved the getRandom function from the DiceTile to the utility class removing TODO.