### PR TITLE
Invalidate capabilities when declaring them

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/anvil/TileAnvilAuto.java
+++ b/src/main/java/com/lothrazar/cyclic/block/anvil/TileAnvilAuto.java
@@ -73,6 +73,13 @@ public class TileAnvilAuto extends TileEntityBase implements INamedContainerProv
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/anvilmagma/TileAnvilMagma.java
+++ b/src/main/java/com/lothrazar/cyclic/block/anvilmagma/TileAnvilMagma.java
@@ -26,6 +26,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -49,11 +50,11 @@ public class TileAnvilMagma extends TileEntityBase implements INamedContainerPro
   ItemStackHandler outputSlots = new ItemStackHandler(1);
   private ItemStackHandlerWrapper inventory = new ItemStackHandlerWrapper(inputSlots, outputSlots);
   private LazyOptional<IItemHandler> inventoryCap = LazyOptional.of(() -> inventory);
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileAnvilMagma() {
     super(TileRegistry.anvil_magma);
-    tank = new FluidTankBase(this, CAPACITY, isFluidValid());
     this.needsRedstone = 0;
   }
 
@@ -119,9 +120,16 @@ public class TileAnvilMagma extends TileEntityBase implements INamedContainerPro
       return inventoryCap.cast();
     }
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/anvilvoid/TileAnvilVoid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/anvilvoid/TileAnvilVoid.java
@@ -27,6 +27,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -51,14 +52,12 @@ public class TileAnvilVoid extends TileEntityBase implements INamedContainerProv
   ItemStackHandler outputSlots = new ItemStackHandler(1);
   private ItemStackHandlerWrapper inventory = new ItemStackHandlerWrapper(inputSlots, outputSlots);
   private LazyOptional<IItemHandler> inventoryCap = LazyOptional.of(() -> inventory);
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, p -> p.getFluid().isIn(DataTags.EXPERIENCE));
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileAnvilVoid() {
     super(TileRegistry.ANVILVOID.get());
     this.needsRedstone = 1;
-    tank = new FluidTankBase(this, CAPACITY, p -> {
-      return p.getFluid().isIn(DataTags.EXPERIENCE);
-    });
   }
 
   @Override
@@ -77,9 +76,16 @@ public class TileAnvilVoid extends TileEntityBase implements INamedContainerProv
       return inventoryCap.cast();
     }
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
+++ b/src/main/java/com/lothrazar/cyclic/block/battery/TileBattery.java
@@ -141,6 +141,12 @@ public class TileBattery extends TileEntityBase implements INamedContainerProvid
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     for (Direction f : Direction.values()) {
       poweredSides.put(f, tag.getBoolean("flow_" + f.getName2()));

--- a/src/main/java/com/lothrazar/cyclic/block/beaconpotion/TilePotion.java
+++ b/src/main/java/com/lothrazar/cyclic/block/beaconpotion/TilePotion.java
@@ -119,6 +119,13 @@ public class TilePotion extends TileEntityBase implements INamedContainerProvide
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     this.radius = tag.getInt("radius");
     entityFilter = EntityFilterType.values()[tag.getInt("entityFilter")];

--- a/src/main/java/com/lothrazar/cyclic/block/cable/CableBase.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/CableBase.java
@@ -214,6 +214,7 @@ public abstract class CableBase extends BlockBase implements IWaterLoggable {
         break;
       }
       if (world.getBlockState(pos).getBlock() == this && world.setBlockState(pos, newState)) {
+        updateConnection(world, pos, sideToToggle, newState.get(prop));
         if (updatePost) {
           newState.updatePostPlacement(sideToToggle, world.getBlockState(pos.offset(sideToToggle)), world, pos, pos.offset(sideToToggle));
         }
@@ -241,5 +242,12 @@ public abstract class CableBase extends BlockBase implements IWaterLoggable {
     return blockState.getBlock() instanceof CableBase
         && blockState.hasProperty(property)
         && blockState.get(property).isUnBlocked() == false;
+  }
+
+  protected void updateConnection(final IWorld world, final BlockPos blockPos, final Direction side, final EnumConnectType connectType) {
+    final TileEntity tileEntity = world.getTileEntity(blockPos);
+    if (tileEntity instanceof TileCableBase) {
+      ((TileCableBase) tileEntity).updateConnection(side, connectType);
+    }
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/TileCableBase.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/TileCableBase.java
@@ -1,10 +1,15 @@
 package com.lothrazar.cyclic.block.cable;
 
 import com.lothrazar.cyclic.base.TileEntityBase;
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 
 public abstract class TileCableBase extends TileEntityBase {
+
+  protected final Map<Direction, EnumConnectType> connectTypeMap = new HashMap<>();
+
   public TileCableBase(TileEntityType<?> tileEntityTypeIn) {
     super(tileEntityTypeIn);
   }
@@ -13,7 +18,11 @@ public abstract class TileCableBase extends TileEntityBase {
 
   public abstract int getField(int field);
 
-  public abstract EnumConnectType getConnectionType(final Direction side);
+  public EnumConnectType getConnectionType(final Direction side) {
+    return connectTypeMap.computeIfAbsent(side, k -> getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(k)));
+  }
 
-  public abstract void updateConnection(final Direction side, final EnumConnectType connectType);
+  public void updateConnection(final Direction side, final EnumConnectType connectType) {
+    connectTypeMap.put(side, connectType);
+  }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/TileCableBase.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/TileCableBase.java
@@ -1,0 +1,19 @@
+package com.lothrazar.cyclic.block.cable;
+
+import com.lothrazar.cyclic.base.TileEntityBase;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.Direction;
+
+public abstract class TileCableBase extends TileEntityBase {
+  public TileCableBase(TileEntityType<?> tileEntityTypeIn) {
+    super(tileEntityTypeIn);
+  }
+
+  public abstract void setField(int field, int value);
+
+  public abstract int getField(int field);
+
+  public abstract EnumConnectType getConnectionType(final Direction side);
+
+  public abstract void updateConnection(final Direction side, final EnumConnectType connectType);
+}

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/BlockCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/BlockCableEnergy.java
@@ -75,7 +75,9 @@ public class BlockCableEnergy extends CableBase {
       IEnergyStorage energy = facingTile == null ? null : facingTile.getCapability(CapabilityEnergy.ENERGY, d.getOpposite()).orElse(null);
       if (energy != null) {
         stateIn = stateIn.with(FACING_TO_PROPERTY_MAP.get(d), EnumConnectType.INVENTORY);
-        worldIn.setBlockState(pos, stateIn);
+        if (worldIn.setBlockState(pos, stateIn)) {
+          updateConnection(worldIn, pos, d, EnumConnectType.INVENTORY);
+        }
       }
     }
     super.onBlockPlacedBy(worldIn, pos, stateIn, placer, stack);
@@ -86,17 +88,21 @@ public class BlockCableEnergy extends CableBase {
     EnumProperty<EnumConnectType> property = FACING_TO_PROPERTY_MAP.get(facing);
     EnumConnectType oldProp = stateIn.get(property);
     if (oldProp.isBlocked() || oldProp.isExtraction()) {
+      updateConnection(world, currentPos, facing, oldProp);
       return stateIn;
     }
     if (isEnergy(stateIn, facing, facingState, world, currentPos, facingPos)) {
       BlockState with = stateIn.with(property, EnumConnectType.INVENTORY);
       if (world instanceof World && world.getBlockState(currentPos).getBlock() == this) {
         //hack to force {any} -> inventory IF its here
-        ((World) world).setBlockState(currentPos, with);
+        if (((World) world).setBlockState(currentPos, with)) {
+          updateConnection(world, currentPos, facing, EnumConnectType.INVENTORY);
+        }
       }
       return with;
     }
     else {
+      updateConnection(world, currentPos, facing, EnumConnectType.NONE);
       return stateIn.with(property, EnumConnectType.NONE);
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -28,7 +28,6 @@ public class TileCableEnergy extends TileCableBase implements ITickableTileEntit
 
   private static final int MAX = 32000;
   final CustomEnergyStorage energy = new CustomEnergyStorage(MAX, MAX);
-  private final Map<Direction, EnumConnectType> connectTypeMap = new HashMap<>();
   private final LazyOptional<IEnergyStorage> energyCap = LazyOptional.of(() -> energy);
   private final Map<Direction, LazyOptional<IEnergyStorage>> energyCapSides = new HashMap<>();
   private final Map<Direction, Integer> mapIncomingEnergy = Maps.newHashMap();
@@ -39,11 +38,6 @@ public class TileCableEnergy extends TileCableBase implements ITickableTileEntit
     for (Direction f : Direction.values()) {
       mapIncomingEnergy.put(f, 0);
     }
-  }
-
-  @Override
-  public EnumConnectType getConnectionType(final Direction side) {
-    return connectTypeMap.computeIfAbsent(side, k -> getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(k)));
   }
 
   @Override
@@ -59,7 +53,7 @@ public class TileCableEnergy extends TileCableBase implements ITickableTileEntit
     else if (oldConnectType == EnumConnectType.BLOCKED && connectType != EnumConnectType.BLOCKED) {
       energyCapSides.put(side, LazyOptional.of(() -> energy));
     }
-    connectTypeMap.put(side, connectType);
+    super.updateConnection(side, connectType);
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/energy/TileCableEnergy.java
@@ -2,7 +2,6 @@ package com.lothrazar.cyclic.block.cable.energy;
 
 import com.google.common.collect.Maps;
 import com.lothrazar.cyclic.ModCyclic;
-import com.lothrazar.cyclic.block.cable.CableBase;
 import com.lothrazar.cyclic.block.cable.EnumConnectType;
 import com.lothrazar.cyclic.block.cable.TileCableBase;
 import com.lothrazar.cyclic.capability.CustomEnergyStorage;
@@ -14,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.state.EnumProperty;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
@@ -62,8 +60,7 @@ public class TileCableEnergy extends TileCableBase implements ITickableTileEntit
     this.tickDownIncomingPowerFaces();
     this.tickCableFlow();
     for (final Direction extractSide : Direction.values()) {
-      final EnumProperty<EnumConnectType> extractFace = CableBase.FACING_TO_PROPERTY_MAP.get(extractSide);
-      final EnumConnectType connection = this.getBlockState().get(extractFace);
+      final EnumConnectType connection = getConnectionType(extractSide);
       if (connection.isExtraction()) {
         tryExtract(extractSide);
       }
@@ -107,8 +104,7 @@ public class TileCableEnergy extends TileCableBase implements ITickableTileEntit
 
   private void tickCableFlow() {
     for (final Direction outgoingSide : UtilDirection.getAllInDifferentOrder()) {
-      final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
-      final EnumConnectType connection = this.getBlockState().get(outgoingFace);
+      final EnumConnectType connection = getConnectionType(outgoingSide);
       if (connection.isExtraction() || connection.isBlocked()) {
         continue;
       }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/BlockCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/BlockCableFluid.java
@@ -101,7 +101,9 @@ public class BlockCableFluid extends CableBase {
       IFluidHandler cap = facingTile == null ? null : facingTile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, d.getOpposite()).orElse(null);
       if (cap != null) {
         stateIn = stateIn.with(FACING_TO_PROPERTY_MAP.get(d), EnumConnectType.INVENTORY);
-        worldIn.setBlockState(pos, stateIn);
+        if (worldIn.setBlockState(pos, stateIn)) {
+          updateConnection(worldIn, pos, d, EnumConnectType.INVENTORY);
+        }
       }
     }
     super.onBlockPlacedBy(worldIn, pos, stateIn, placer, stack);
@@ -124,17 +126,21 @@ public class BlockCableFluid extends CableBase {
     EnumProperty<EnumConnectType> property = FACING_TO_PROPERTY_MAP.get(facing);
     EnumConnectType oldProp = stateIn.get(property);
     if (oldProp.isBlocked() || oldProp.isExtraction()) {
+      updateConnection(world, currentPos, facing, oldProp);
       return stateIn;
     }
     if (isFluid(stateIn, facing, facingState, world, currentPos, facingPos)) {
       BlockState with = stateIn.with(property, EnumConnectType.INVENTORY);
       if (world instanceof World && world.getBlockState(currentPos).getBlock() == this) {
         //hack to force {any} -> inventory IF its here
-        ((World) world).setBlockState(currentPos, with);
+        if (((World) world).setBlockState(currentPos, with)) {
+          updateConnection(world, currentPos, facing, EnumConnectType.INVENTORY);
+        }
       }
       return with;
     }
     else {
+      updateConnection(world, currentPos, facing, EnumConnectType.NONE);
       return stateIn.with(property, EnumConnectType.NONE);
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -23,7 +23,6 @@ import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.state.EnumProperty;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.util.Direction;
@@ -79,8 +78,7 @@ public class TileCableFluid extends TileCableBase implements ITickableTileEntity
   @Override
   public void tick() {
     for (final Direction extractSide : Direction.values()) {
-      final EnumProperty<EnumConnectType> extractFace = CableBase.FACING_TO_PROPERTY_MAP.get(extractSide);
-      final EnumConnectType connection = this.getBlockState().get(extractFace);
+      final EnumConnectType connection = getConnectionType(extractSide);
       if (connection.isExtraction()) {
         tryExtract(extractSide);
       }
@@ -144,8 +142,7 @@ public class TileCableFluid extends TileCableBase implements ITickableTileEntity
 
   private void normalFlow() {
     for (final Direction outgoingSide : UtilDirection.getAllInDifferentOrder()) {
-      final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
-      final EnumConnectType connection = this.getBlockState().get(outgoingFace);
+      final EnumConnectType connection = getConnectionType(outgoingSide);
       if (connection.isExtraction() || connection.isBlocked()) {
         continue;
       }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/fluid/TileCableFluid.java
@@ -54,17 +54,11 @@ public class TileCableFluid extends TileCableBase implements ITickableTileEntity
   public static final int EXTRACT_RATE = CAPACITY;
   private final FluidTank fluidTank = new FluidTankBase(this, CAPACITY, fluidStack ->
     FilterCardItem.filterAllowsExtract(filter.getStackInSlot(0), fluidStack));
-  private final Map<Direction, EnumConnectType> connectTypeMap = new HashMap<>();
   private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> fluidTank);
   private final Map<Direction, LazyOptional<IFluidHandler>> fluidCapSides = new HashMap<>();
 
   public TileCableFluid() {
     super(TileRegistry.fluid_pipeTile);
-  }
-
-  @Override
-  public EnumConnectType getConnectionType(final Direction side) {
-    return connectTypeMap.computeIfAbsent(side, k -> getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(k)));
   }
 
   @Override
@@ -79,7 +73,7 @@ public class TileCableFluid extends TileCableBase implements ITickableTileEntity
     else if (oldConnectType == EnumConnectType.BLOCKED && connectType != EnumConnectType.BLOCKED) {
       fluidCapSides.put(side, LazyOptional.of(() -> fluidTank));
     }
-    connectTypeMap.put(side, connectType);
+    super.updateConnection(side, connectType);
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/BlockCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/BlockCableItem.java
@@ -106,6 +106,7 @@ public class BlockCableItem extends CableBase {
       if (cap != null) {
         stateIn = stateIn.with(FACING_TO_PROPERTY_MAP.get(d), EnumConnectType.INVENTORY);
         worldIn.setBlockState(pos, stateIn);
+        updateConnection(worldIn, pos, d, EnumConnectType.INVENTORY);
       }
     }
     super.onBlockPlacedBy(worldIn, pos, stateIn, placer, stack);
@@ -116,17 +117,21 @@ public class BlockCableItem extends CableBase {
     EnumProperty<EnumConnectType> property = FACING_TO_PROPERTY_MAP.get(facing);
     EnumConnectType oldProp = stateIn.get(property);
     if (oldProp.isBlocked() || oldProp.isExtraction()) {
+      updateConnection(world, currentPos, facing, oldProp);
       return stateIn;
     }
     if (isItem(stateIn, facing, facingState, world, currentPos, facingPos)) {
       BlockState with = stateIn.with(property, EnumConnectType.INVENTORY);
       if (world instanceof World && world.getBlockState(currentPos).getBlock() == this) {
         //hack to force {any} -> inventory IF its here
-        ((World) world).setBlockState(currentPos, with);
+        if (((World) world).setBlockState(currentPos, with)) {
+          updateConnection(world, currentPos, facing, EnumConnectType.INVENTORY);
+        }
       }
       return with;
     }
     else {
+      updateConnection(world, currentPos, facing, EnumConnectType.NONE);
       return stateIn.with(property, EnumConnectType.NONE);
     }
   }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -1,6 +1,5 @@
 package com.lothrazar.cyclic.block.cable.item;
 
-import com.lothrazar.cyclic.block.cable.CableBase;
 import com.lothrazar.cyclic.block.cable.EnumConnectType;
 import com.lothrazar.cyclic.block.cable.TileCableBase;
 import com.lothrazar.cyclic.item.datacard.filter.FilterCardItem;
@@ -16,7 +15,6 @@ import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.state.EnumProperty;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
@@ -52,10 +50,6 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
     super(TileRegistry.item_pipeTile);
   }
 
-  private static ItemStackHandler createHandler() {
-    return new ItemStackHandler(1);
-  }
-
   @Override
   public void updateConnection(final Direction side, final EnumConnectType connectType) {
     final EnumConnectType oldConnectType = getConnectionType(side);
@@ -74,8 +68,7 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
   @Override
   public void tick() {
     for (final Direction extractSide : Direction.values()) {
-      final EnumProperty<EnumConnectType> extractFace = CableBase.FACING_TO_PROPERTY_MAP.get(extractSide);
-      final EnumConnectType connection = this.getBlockState().get(extractFace);
+      final EnumConnectType connection = getConnectionType(extractSide);
       if (connection.isExtraction()) {
         tryExtract(itemHandler, extractSide, extractQty, filter);
       }
@@ -91,11 +84,7 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
         if (outgoingSide == incomingSide) {
           continue;
         }
-        if (getConnectionType(outgoingSide) == EnumConnectType.BLOCKED) {
-          continue;
-        }
-        final EnumProperty<EnumConnectType> outgoingFace = CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide);
-        final EnumConnectType outgoingConnection = this.getBlockState().get(outgoingFace);
+        final EnumConnectType outgoingConnection = getConnectionType(outgoingSide);
         if (outgoingConnection.isExtraction() || outgoingConnection.isBlocked()) {
           continue;
         }

--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -45,7 +45,6 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
       return FilterCardItem.filterAllowsExtract(filter.getStackInSlot(0), stack);
     }
   };
-  private final Map<Direction, EnumConnectType> connectTypeMap = new HashMap<>();
   private final LazyOptional<IItemHandler> itemCap = LazyOptional.of(() -> itemHandler);
   private final Map<Direction, LazyOptional<IItemHandler>> itemCapSides = new HashMap<>();
 
@@ -55,11 +54,6 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
 
   private static ItemStackHandler createHandler() {
     return new ItemStackHandler(1);
-  }
-
-  @Override
-  public EnumConnectType getConnectionType(final Direction side) {
-    return connectTypeMap.computeIfAbsent(side, k -> getBlockState().get(CableBase.FACING_TO_PROPERTY_MAP.get(k)));
   }
 
   @Override
@@ -74,7 +68,7 @@ public class TileCableItem extends TileCableBase implements ITickableTileEntity,
     else if (oldConnectType == EnumConnectType.BLOCKED && connectType != EnumConnectType.BLOCKED) {
       itemCapSides.put(side, LazyOptional.of(() -> itemHandler));
     }
-    connectTypeMap.put(side, connectType);
+    super.updateConnection(side, connectType);
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/collectfluid/TileFluidCollect.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectfluid/TileFluidCollect.java
@@ -174,6 +174,14 @@ public class TileFluidCollect extends TileEntityBase implements ITickableTileEnt
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    tankWrapper.invalidate();
+    energyCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     shapeIndex = tag.getInt("shapeIndex");
     tank.readFromNBT(tag.getCompound(NBTFLUID));

--- a/src/main/java/com/lothrazar/cyclic/block/collectitem/TileItemCollector.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectitem/TileItemCollector.java
@@ -106,6 +106,12 @@ public class TileItemCollector extends TileEntityBase implements ITickableTileEn
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     filter.deserializeNBT(tag.getCompound("filter"));
     radius = tag.getInt("radius");

--- a/src/main/java/com/lothrazar/cyclic/block/crafter/TileCrafter.java
+++ b/src/main/java/com/lothrazar/cyclic/block/crafter/TileCrafter.java
@@ -479,6 +479,17 @@ public class TileCrafter extends TileEntityBase implements INamedContainerProvid
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    input.invalidate();
+    output.invalidate();
+    gridCap.invalidate();
+    preview.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energyCap.ifPresent(h -> ((INBTSerializable<CompoundNBT>) h).deserializeNBT(tag.getCompound("energy")));
     input.ifPresent(h -> ((INBTSerializable<CompoundNBT>) h).deserializeNBT(tag.getCompound("input")));

--- a/src/main/java/com/lothrazar/cyclic/block/crate/TileCrate.java
+++ b/src/main/java/com/lothrazar/cyclic/block/crate/TileCrate.java
@@ -45,6 +45,12 @@ public class TileCrate extends TileEntityBase implements INamedContainerProvider
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     super.read(bs, tag);

--- a/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
+++ b/src/main/java/com/lothrazar/cyclic/block/creativebattery/TileBatteryInfinite.java
@@ -58,6 +58,12 @@ public class TileBatteryInfinite extends TileEntityBase implements ITickableTile
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     for (Direction f : Direction.values()) {
       poweredSides.put(f, tag.getBoolean("flow_" + f.getName2()));

--- a/src/main/java/com/lothrazar/cyclic/block/creativeitem/TileItemInfinite.java
+++ b/src/main/java/com/lothrazar/cyclic/block/creativeitem/TileItemInfinite.java
@@ -42,6 +42,12 @@ public class TileItemInfinite extends TileEntityBase implements ITickableTileEnt
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public CompoundNBT write(CompoundNBT tag) {
     tag.put(NBTINV, inventory.serializeNBT());
     return super.write(tag);

--- a/src/main/java/com/lothrazar/cyclic/block/disenchant/TileDisenchant.java
+++ b/src/main/java/com/lothrazar/cyclic/block/disenchant/TileDisenchant.java
@@ -35,6 +35,7 @@ import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -71,13 +72,11 @@ public class TileDisenchant extends TileEntityBase implements INamedContainerPro
   public static IntValue POWERCONF;
   public static IntValue FLUIDCOST;
   private LazyOptional<IEnergyStorage> energyCap = LazyOptional.of(() -> energy);
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, p -> p.getFluid().isIn(DataTags.EXPERIENCE));
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileDisenchant() {
     super(TileRegistry.disenchanter);
-    tank = new FluidTankBase(this, CAPACITY, p -> {
-      return p.getFluid().isIn(DataTags.EXPERIENCE);
-    });
   }
 
   @Override
@@ -200,9 +199,17 @@ public class TileDisenchant extends TileEntityBase implements INamedContainerPro
       return energyCap.cast();
     }
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    energyCap.invalidate();
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/dropper/TileDropper.java
+++ b/src/main/java/com/lothrazar/cyclic/block/dropper/TileDropper.java
@@ -107,6 +107,13 @@ public class TileDropper extends TileEntityBase implements INamedContainerProvid
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/enderctrl/TileEnderCtrl.java
+++ b/src/main/java/com/lothrazar/cyclic/block/enderctrl/TileEnderCtrl.java
@@ -66,6 +66,12 @@ public class TileEnderCtrl extends TileEntityBase {
   }
 
   @Override
+  public void invalidateCaps() {
+    controllerInventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     if (tag.contains("RenderTextType")) {
       int rt = tag.getInt("RenderTextType");

--- a/src/main/java/com/lothrazar/cyclic/block/enderitemshelf/TileItemShelf.java
+++ b/src/main/java/com/lothrazar/cyclic/block/enderitemshelf/TileItemShelf.java
@@ -39,6 +39,12 @@ public class TileItemShelf extends TileEntityBase {
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     if (tag.contains("RenderTextType")) {

--- a/src/main/java/com/lothrazar/cyclic/block/endershelf/TileEnderShelf.java
+++ b/src/main/java/com/lothrazar/cyclic/block/endershelf/TileEnderShelf.java
@@ -40,6 +40,12 @@ public class TileEnderShelf extends TileEntityBase {
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     if (tag.contains("RenderTextType")) {

--- a/src/main/java/com/lothrazar/cyclic/block/expcollect/TileExpPylon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/expcollect/TileExpPylon.java
@@ -27,6 +27,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 public class TileExpPylon extends TileEntityBase implements ITickableTileEntity, INamedContainerProvider {
@@ -41,11 +42,11 @@ public class TileExpPylon extends TileEntityBase implements ITickableTileEntity,
   public static final int EXP_PER_BOTTLE = 11;
   private static final int RADIUS = 16;
   public static final int CAPACITY = 64000 * FluidAttributes.BUCKET_VOLUME;
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+  private LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileExpPylon() {
     super(TileRegistry.experience_pylontile);
-    tank = new FluidTankBase(this, CAPACITY, isFluidValid());
     this.needsRedstone = 0;
   }
 
@@ -69,9 +70,15 @@ public class TileExpPylon extends TileEntityBase implements ITickableTileEntity,
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/expcollect/TileExpPylon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/expcollect/TileExpPylon.java
@@ -43,7 +43,7 @@ public class TileExpPylon extends TileEntityBase implements ITickableTileEntity,
   private static final int RADIUS = 16;
   public static final int CAPACITY = 64000 * FluidAttributes.BUCKET_VOLUME;
   public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
-  private LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileExpPylon() {
     super(TileRegistry.experience_pylontile);

--- a/src/main/java/com/lothrazar/cyclic/block/fishing/TileFisher.java
+++ b/src/main/java/com/lothrazar/cyclic/block/fishing/TileFisher.java
@@ -78,6 +78,12 @@ public class TileFisher extends TileEntityBase implements ITickableTileEntity, I
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     super.read(bs, tag);

--- a/src/main/java/com/lothrazar/cyclic/block/forester/TileForester.java
+++ b/src/main/java/com/lothrazar/cyclic/block/forester/TileForester.java
@@ -153,6 +153,13 @@ public class TileForester extends TileEntityBase implements INamedContainerProvi
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     shapeIndex = tag.getInt("shapeIndex");
     radius = tag.getInt("radius");

--- a/src/main/java/com/lothrazar/cyclic/block/generatorfluid/TileGeneratorFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatorfluid/TileGeneratorFluid.java
@@ -146,6 +146,13 @@ public class TileGeneratorFluid extends TileEntityBase implements INamedContaine
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     tank.readFromNBT(tag.getCompound(NBTFLUID));
     energy.deserializeNBT(tag.getCompound(NBTENERGY));

--- a/src/main/java/com/lothrazar/cyclic/block/generatorfood/TileGeneratorFood.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatorfood/TileGeneratorFood.java
@@ -120,6 +120,13 @@ public class TileGeneratorFood extends TileEntityBase implements INamedContainer
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/generatorfuel/TileGeneratorFuel.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatorfuel/TileGeneratorFuel.java
@@ -117,6 +117,13 @@ public class TileGeneratorFuel extends TileEntityBase implements INamedContainer
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/generatoritem/TileGeneratorDrops.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatoritem/TileGeneratorDrops.java
@@ -134,6 +134,13 @@ public class TileGeneratorDrops extends TileEntityBase implements INamedContaine
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/generatorpeat/TileGeneratorPeat.java
+++ b/src/main/java/com/lothrazar/cyclic/block/generatorpeat/TileGeneratorPeat.java
@@ -53,6 +53,13 @@ public class TileGeneratorPeat extends TileEntityBase implements ITickableTileEn
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     setFlowing(tag.getInt("flowing"));
     fuelRate = tag.getInt("fuelRate");

--- a/src/main/java/com/lothrazar/cyclic/block/harvester/TileHarvester.java
+++ b/src/main/java/com/lothrazar/cyclic/block/harvester/TileHarvester.java
@@ -270,6 +270,12 @@ public class TileHarvester extends TileEntityBase implements ITickableTileEntity
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     radius = tag.getInt("radius");
     height = tag.getInt("height");

--- a/src/main/java/com/lothrazar/cyclic/block/hopper/TileSimpleHopper.java
+++ b/src/main/java/com/lothrazar/cyclic/block/hopper/TileSimpleHopper.java
@@ -42,6 +42,12 @@ public class TileSimpleHopper extends TileEntityBase implements ITickableTileEnt
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void tick() {
     //block if redstone powered
     if (this.isPowered()) {

--- a/src/main/java/com/lothrazar/cyclic/block/hopperfluid/TileFluidHopper.java
+++ b/src/main/java/com/lothrazar/cyclic/block/hopperfluid/TileFluidHopper.java
@@ -26,6 +26,7 @@ public class TileFluidHopper extends TileEntityBase implements ITickableTileEnti
   private static final int FLOW = FluidAttributes.BUCKET_VOLUME;
   public static final int CAPACITY = FluidAttributes.BUCKET_VOLUME;
   public FluidTankBase tank = new FluidTankBase(this, CAPACITY, p -> true);
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileFluidHopper() {
     super(TileRegistry.FLUIDHOPPER.get());
@@ -34,9 +35,15 @@ public class TileFluidHopper extends TileEntityBase implements ITickableTileEnti
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/laser/TileLaser.java
+++ b/src/main/java/com/lothrazar/cyclic/block/laser/TileLaser.java
@@ -61,6 +61,12 @@ public class TileLaser extends TileEntityBase implements INamedContainerProvider
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public ITextComponent getDisplayName() {
     return new StringTextComponent(getType().getRegistryName().getPath());
   }

--- a/src/main/java/com/lothrazar/cyclic/block/lightcompr/TileLightCamo.java
+++ b/src/main/java/com/lothrazar/cyclic/block/lightcompr/TileLightCamo.java
@@ -51,6 +51,12 @@ public class TileLightCamo extends TileEntityBase {
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void setField(int field, int value) {}
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/melter/TileMelter.java
+++ b/src/main/java/com/lothrazar/cyclic/block/melter/TileMelter.java
@@ -45,7 +45,7 @@ public class TileMelter extends TileEntityBase implements ITickableTileEntity, I
   public static final int TRANSFER_FLUID_PER_TICK = FluidAttributes.BUCKET_VOLUME / 20;
   public static final int TIMER_FULL = Const.TICKS_PER_SEC * 3;
   public static IntValue POWERCONF;
-  public FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
   CustomEnergyStorage energy = new CustomEnergyStorage(MAX, MAX);
   ItemStackHandler inventory = new ItemStackHandler(2);
   private LazyOptional<IEnergyStorage> energyCap = LazyOptional.of(() -> energy);

--- a/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
+++ b/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
@@ -117,6 +117,13 @@ public class TileMiner extends TileEntityBase implements INamedContainerProvider
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     radius = tag.getInt("size");
     height = tag.getInt("height");

--- a/src/main/java/com/lothrazar/cyclic/block/packager/TilePackager.java
+++ b/src/main/java/com/lothrazar/cyclic/block/packager/TilePackager.java
@@ -173,6 +173,13 @@ public class TilePackager extends TileEntityBase implements INamedContainerProvi
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
+++ b/src/main/java/com/lothrazar/cyclic/block/peatfarm/TilePeatFarm.java
@@ -257,6 +257,14 @@ public class TilePeatFarm extends TileEntityBase implements ITickableTileEntity,
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    tankWrapper.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     tank.readFromNBT(tag.getCompound(NBTFLUID));
     energy.deserializeNBT(tag.getCompound(NBTENERGY));

--- a/src/main/java/com/lothrazar/cyclic/block/placer/TilePlacer.java
+++ b/src/main/java/com/lothrazar/cyclic/block/placer/TilePlacer.java
@@ -81,6 +81,12 @@ public class TilePlacer extends TileEntityBase implements INamedContainerProvide
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     super.read(bs, tag);

--- a/src/main/java/com/lothrazar/cyclic/block/placerfluid/TilePlacerFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/placerfluid/TilePlacerFluid.java
@@ -21,12 +21,14 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 public class TilePlacerFluid extends TileEntityBase implements INamedContainerProvider, ITickableTileEntity {
 
   public static final int CAPACITY = 8 * FluidAttributes.BUCKET_VOLUME;
-  FluidTankBase tank;
+  private final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   static enum Fields {
     REDSTONE, RENDER;
@@ -34,7 +36,6 @@ public class TilePlacerFluid extends TileEntityBase implements INamedContainerPr
 
   public TilePlacerFluid() {
     super(TileRegistry.placer_fluid);
-    tank = new FluidTankBase(this, CAPACITY, isFluidValid());
     this.needsRedstone = 1;
   }
 
@@ -89,9 +90,15 @@ public class TilePlacerFluid extends TileEntityBase implements INamedContainerPr
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
       //      return tankWrapper.cast();
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/shapebuilder/TileStructure.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapebuilder/TileStructure.java
@@ -136,6 +136,13 @@ public class TileStructure extends TileEntityBase implements INamedContainerProv
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void setField(int field, int value) {
     switch (Fields.values()[field]) {
       case TIMER:

--- a/src/main/java/com/lothrazar/cyclic/block/shapedata/TileShapedata.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapedata/TileShapedata.java
@@ -140,6 +140,12 @@ public class TileShapedata extends TileEntityBase implements INamedContainerProv
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     if (tag.contains("copiedShape")) {

--- a/src/main/java/com/lothrazar/cyclic/block/solidifier/TileSolidifier.java
+++ b/src/main/java/com/lothrazar/cyclic/block/solidifier/TileSolidifier.java
@@ -154,6 +154,14 @@ public class TileSolidifier extends TileEntityBase implements ITickableTileEntit
     return super.getCapability(cap, side);
   }
 
+  @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    tankWrapper.invalidate();
+    super.invalidateCaps();
+  }
+
   public float getCapacity() {
     return CAPACITY;
   }

--- a/src/main/java/com/lothrazar/cyclic/block/soundmuff/ghost/SoundmuffTile.java
+++ b/src/main/java/com/lothrazar/cyclic/block/soundmuff/ghost/SoundmuffTile.java
@@ -46,6 +46,12 @@ public class SoundmuffTile extends TileEntityBase {
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public AxisAlignedBB getRenderBoundingBox() {
     return TileEntity.INFINITE_EXTENT_AABB;
   }

--- a/src/main/java/com/lothrazar/cyclic/block/soundplay/TileSoundPlayer.java
+++ b/src/main/java/com/lothrazar/cyclic/block/soundplay/TileSoundPlayer.java
@@ -81,6 +81,12 @@ public class TileSoundPlayer extends TileEntityBase implements INamedContainerPr
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void setField(int field, int value) {}
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/soundrecord/TileSoundRecorder.java
+++ b/src/main/java/com/lothrazar/cyclic/block/soundrecord/TileSoundRecorder.java
@@ -99,6 +99,12 @@ public class TileSoundRecorder extends TileEntityBase implements INamedContainer
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void setField(int field, int value) {
     switch (Fields.values()[field]) {
       case CLEARALL:

--- a/src/main/java/com/lothrazar/cyclic/block/sprinkler/TileSprinkler.java
+++ b/src/main/java/com/lothrazar/cyclic/block/sprinkler/TileSprinkler.java
@@ -23,6 +23,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 public class TileSprinkler extends TileEntityBase implements ITickableTileEntity {
@@ -31,12 +32,12 @@ public class TileSprinkler extends TileEntityBase implements ITickableTileEntity
   public static IntValue TIMER_FULL;
   public static IntValue WATERCOST;
   private static final int RAD = 4;
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, p -> p.getFluid() == Fluids.WATER);
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
   private int shapeIndex = 0;
 
   public TileSprinkler() {
     super(TileRegistry.SPRINKLER.get());
-    tank = new FluidTankBase(this, CAPACITY, p -> p.getFluid() == Fluids.WATER);
   }
 
   @Override
@@ -105,9 +106,15 @@ public class TileSprinkler extends TileEntityBase implements ITickableTileEntity
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/tank/TileTank.java
+++ b/src/main/java/com/lothrazar/cyclic/block/tank/TileTank.java
@@ -14,16 +14,17 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class TileTank extends TileEntityBase implements ITickableTileEntity {
 
   public static final int CAPACITY = 64 * FluidAttributes.BUCKET_VOLUME;
   public static final int TRANSFER_FLUID_PER_TICK = FluidAttributes.BUCKET_VOLUME / 20;
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, p -> true);
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   public TileTank() {
     super(TileRegistry.tank);
-    tank = new FluidTankBase(this, CAPACITY, p -> true);
   }
 
   @Override
@@ -43,9 +44,14 @@ public class TileTank extends TileEntityBase implements ITickableTileEntity {
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
+++ b/src/main/java/com/lothrazar/cyclic/block/tankcask/TileCask.java
@@ -16,13 +16,15 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class TileCask extends TileEntityBase implements ITickableTileEntity {
 
   private Map<Direction, Boolean> poweredSides;
   public static final int CAPACITY = 8 * FluidAttributes.BUCKET_VOLUME;
   public static final int TRANSFER_FLUID_PER_TICK = CAPACITY / 2;
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, isFluidValid());
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
 
   static enum Fields {
     FLOWING, N, E, S, W, U, D;
@@ -31,7 +33,6 @@ public class TileCask extends TileEntityBase implements ITickableTileEntity {
   public TileCask() {
     super(TileRegistry.cask);
     flowing = 0;
-    tank = new FluidTankBase(this, CAPACITY, isFluidValid());
     poweredSides = new HashMap<Direction, Boolean>();
     for (Direction f : Direction.values()) {
       poweredSides.put(f, false);
@@ -70,6 +71,12 @@ public class TileCask extends TileEntityBase implements ITickableTileEntity {
       return LazyOptional.of(() -> tank).cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/trash/TileTrash.java
+++ b/src/main/java/com/lothrazar/cyclic/block/trash/TileTrash.java
@@ -49,6 +49,13 @@ public class TileTrash extends TileEntityBase implements ITickableTileEntity {
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    tankWrapper.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     super.read(bs, tag);

--- a/src/main/java/com/lothrazar/cyclic/block/uncrafter/TileUncraft.java
+++ b/src/main/java/com/lothrazar/cyclic/block/uncrafter/TileUncraft.java
@@ -146,6 +146,13 @@ public class TileUncraft extends TileEntityBase implements ITickableTileEntity, 
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));

--- a/src/main/java/com/lothrazar/cyclic/block/user/TileUser.java
+++ b/src/main/java/com/lothrazar/cyclic/block/user/TileUser.java
@@ -178,6 +178,13 @@ public class TileUser extends TileEntityBase implements ITickableTileEntity, INa
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     timerDelay = tag.getInt("delay");
     energy.deserializeNBT(tag.getCompound(NBTENERGY));

--- a/src/main/java/com/lothrazar/cyclic/block/wireless/energy/TileWirelessEnergy.java
+++ b/src/main/java/com/lothrazar/cyclic/block/wireless/energy/TileWirelessEnergy.java
@@ -66,6 +66,12 @@ public class TileWirelessEnergy extends TileEntityBase implements INamedContaine
   }
 
   @Override
+  public void invalidateCaps() {
+    energyCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     gpsSlots.deserializeNBT(tag.getCompound(NBTINV));
     energy.deserializeNBT(tag.getCompound(NBTENERGY));

--- a/src/main/java/com/lothrazar/cyclic/block/wireless/fluid/TileWirelessFluid.java
+++ b/src/main/java/com/lothrazar/cyclic/block/wireless/fluid/TileWirelessFluid.java
@@ -22,6 +22,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
 public class TileWirelessFluid extends TileEntityBase implements INamedContainerProvider, ITickableTileEntity {
@@ -34,7 +35,8 @@ public class TileWirelessFluid extends TileEntityBase implements INamedContainer
   static final int MAX = 64000;
   public static final int MAX_TRANSFER = MAX;
   private int transferRate = FluidAttributes.BUCKET_VOLUME;
-  public FluidTankBase tank;
+  public final FluidTankBase tank = new FluidTankBase(this, CAPACITY, f -> true);
+  private final LazyOptional<IFluidHandler> fluidCap = LazyOptional.of(() -> tank);
   ItemStackHandler gpsSlots = new ItemStackHandler(1) {
 
     @Override
@@ -46,7 +48,6 @@ public class TileWirelessFluid extends TileEntityBase implements INamedContainer
   public TileWirelessFluid() {
     super(TileRegistry.WIRELESS_FLUID.get());
     this.needsRedstone = 0;
-    tank = new FluidTankBase(this, CAPACITY, f -> true);
   }
 
   @Override
@@ -62,9 +63,15 @@ public class TileWirelessFluid extends TileEntityBase implements INamedContainer
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
     if (cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-      return LazyOptional.of(() -> tank).cast();
+      return fluidCap.cast();
     }
     return super.getCapability(cap, side);
+  }
+
+  @Override
+  public void invalidateCaps() {
+    fluidCap.invalidate();
+    super.invalidateCaps();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/wireless/item/TileWirelessItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/wireless/item/TileWirelessItem.java
@@ -64,6 +64,12 @@ public class TileWirelessItem extends TileEntityBase implements INamedContainerP
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     gpsSlots.deserializeNBT(tag.getCompound(NBTINV + "gps"));

--- a/src/main/java/com/lothrazar/cyclic/block/wireless/redstone/TileWirelessTransmit.java
+++ b/src/main/java/com/lothrazar/cyclic/block/wireless/redstone/TileWirelessTransmit.java
@@ -62,6 +62,12 @@ public class TileWirelessTransmit extends TileEntityBase implements INamedContai
   }
 
   @Override
+  public void invalidateCaps() {
+    inventoryCap.invalidate();
+    super.invalidateCaps();
+  }
+
+  @Override
   public void read(BlockState bs, CompoundNBT tag) {
     inventory.deserializeNBT(tag.getCompound(NBTINV));
     super.read(bs, tag);


### PR DESCRIPTION
getCapability was overridden without ever overriding invalidateCaps. This allows correct caching behaviour of energy, fluid and item capabilities by this and other mods.