### PR TITLE
Inventory cake bug

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/item/food/inventorycake/ItemCakeInventory.java
+++ b/src/main/java/com/lothrazar/cyclic/item/food/inventorycake/ItemCakeInventory.java
@@ -50,8 +50,10 @@ public class ItemCakeInventory extends ItemBaseCyclic {
     Player player = (Player) entityLiving;
     if (!worldIn.isClientSide) {
       CyclicFile datFile = PlayerDataEvents.getOrCreate(player);
-      datFile.storageVisible = !datFile.storageVisible;
-      ChatUtil.addServerChatMessage(player, "cyclic.unlocks.extended");
+      if (!datFile.storageVisible) {
+        datFile.storageVisible = true;
+        ChatUtil.addServerChatMessage(player, "cyclic.unlocks.extended");
+      }
     }
     return super.finishUsingItem(stack, worldIn, entityLiving);
   }


### PR DESCRIPTION
Fixes issue where extended inventory would become unavailable upon eating the inventory cake a second time. The extended inventory would now be permanently unlocked after eating the cake.