### PR TITLE
Optimize anti beacon to not deadlock worldgen or lag entities

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/antipotion/BlockAntiBeacon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/antipotion/BlockAntiBeacon.java
@@ -141,11 +141,17 @@ public class BlockAntiBeacon extends BlockCyclic {
       }
 
       BlockPos closestAntiBeacon = livingEntityData.getClosestAntiBeaconPosition();
-      if (closestAntiBeacon == null || livingEntity.blockPosition().distManhattan(closestAntiBeacon) > TileAntiBeacon.RADIUS.get()) {
+      if (closestAntiBeacon == null) {
+        return;
+      }
+
+      if (livingEntity.blockPosition().distManhattan(closestAntiBeacon) > TileAntiBeacon.RADIUS.get()) {
+        livingEntityData.setClosestAntiBeaconPosition(null);
         return;
       }
 
       if (!serverLevel.getBlockState(closestAntiBeacon).getBlock().equals(this)) {
+        livingEntityData.setClosestAntiBeaconPosition(null);
         return;
       }
 

--- a/src/main/java/com/lothrazar/cyclic/block/antipotion/BlockAntiBeacon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/antipotion/BlockAntiBeacon.java
@@ -1,15 +1,16 @@
 package com.lothrazar.cyclic.block.antipotion;
 
-import java.util.ArrayList;
-import java.util.List;
 import com.lothrazar.cyclic.ModCyclic;
 import com.lothrazar.cyclic.block.BlockCyclic;
+import com.lothrazar.cyclic.capabilities.livingentity.LivingEntityCapProvider;
+import com.lothrazar.cyclic.capabilities.livingentity.LivingEntityCapabilityStorage;
+import com.lothrazar.cyclic.registry.BlockRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
-import com.lothrazar.library.util.BlockstatesUtil;
 import com.lothrazar.library.util.EntityUtil;
 import com.lothrazar.library.util.StringParseUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.LivingEntity;
@@ -25,6 +26,9 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.event.entity.living.MobEffectEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
 import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BlockAntiBeacon extends BlockCyclic {
 
@@ -74,6 +78,29 @@ public class BlockAntiBeacon extends BlockCyclic {
     }
   }
 
+  public static void markNearbyEntitiesWithAntiBeaconPosition(Level world, BlockPos pos) {
+    List<LivingEntity> all = world.getEntitiesOfClass(LivingEntity.class, EntityUtil.makeBoundingBox(pos, TileAntiBeacon.RADIUS.get(), TileAntiBeacon.RADIUS.get()));
+    for (LivingEntity e : all) {
+      LivingEntityCapabilityStorage livingEntityData = e.getCapability(LivingEntityCapProvider.CYCLIC_LIVING_ENTITY).orElse(null);
+      if (livingEntityData == null) {
+        continue;
+      }
+
+      BlockPos oldPosition = livingEntityData.getClosestAntiBeaconPosition();
+      if (oldPosition != null && world.getBlockState(oldPosition).is(BlockRegistry.ANTI_BEACON.get())) {
+        int oldDistance = e.blockPosition().distManhattan(oldPosition);
+        int newDistance = e.blockPosition().distManhattan(pos);
+
+        if (newDistance < oldDistance) {
+          livingEntityData.setClosestAntiBeaconPosition(pos);
+        }
+      }
+      else {
+        livingEntityData.setClosestAntiBeaconPosition(pos);
+      }
+    }
+  }
+
   private static void cureAllRelevant(LivingEntity e) {
     List<MobEffect> cureMe = new ArrayList<>();
     for (MobEffect mobEffect : e.getActiveEffectsMap().keySet()) {
@@ -101,16 +128,35 @@ public class BlockAntiBeacon extends BlockCyclic {
     if (event.getEffectInstance() == null) {
       return;
     }
+
     //this will cancel it
-    if (BlockAntiBeacon.doesConfigBlockEffect(event.getEffectInstance().getEffect())) {
-      final boolean isPowered = false; // if im NOT powered, im running
-      List<BlockPos> blocks = BlockstatesUtil.findBlocks(event.getEntity().getCommandSenderWorld(),
-          event.getEntity().blockPosition(), this, TileAntiBeacon.RADIUS.get(), isPowered);
-      //can
-      if (blocks != null && blocks.size() > 0) {
-        ModCyclic.LOGGER.info("[potion blocked] " + event.getEffectInstance());
-        event.setResult(Result.DENY);
+    LivingEntity livingEntity = event.getEntity();
+    if (BlockAntiBeacon.doesConfigBlockEffect(event.getEffectInstance().getEffect()) &&
+            livingEntity.getCommandSenderWorld() instanceof ServerLevel serverLevel &&
+            serverLevel.isLoaded(livingEntity.blockPosition())) {
+
+      LivingEntityCapabilityStorage livingEntityData = livingEntity.getCapability(LivingEntityCapProvider.CYCLIC_LIVING_ENTITY).orElse(null);
+      if (livingEntityData == null) {
+        return;
       }
+
+      BlockPos closestAntiBeacon = livingEntityData.getClosestAntiBeaconPosition();
+      if (closestAntiBeacon == null || livingEntity.blockPosition().distManhattan(closestAntiBeacon) > TileAntiBeacon.RADIUS.get()) {
+        return;
+      }
+
+      if (!serverLevel.getBlockState(closestAntiBeacon).getBlock().equals(this)) {
+        return;
+      }
+
+      final boolean isPowered = false; // if im NOT powered, im running
+      if (serverLevel.hasNeighborSignal(closestAntiBeacon) != isPowered) {
+        return;
+      }
+
+      //can
+      ModCyclic.LOGGER.info("[potion blocked] " + event.getEffectInstance());
+      event.setResult(Result.DENY);
     }
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/antipotion/TileAntiBeacon.java
+++ b/src/main/java/com/lothrazar/cyclic/block/antipotion/TileAntiBeacon.java
@@ -33,8 +33,12 @@ public class TileAntiBeacon extends TileBlockEntityCyclic {
     //ok go
     tile.tick(level, blockPos);
     if (tile.timer <= 0) {
+      BlockAntiBeacon.markNearbyEntitiesWithAntiBeaconPosition(level, blockPos);
       BlockAntiBeacon.absorbPotions(level, blockPos);
       tile.timer = TICKS.get();
+    }
+    else {
+      tile.timer--;
     }
   }
 

--- a/src/main/java/com/lothrazar/cyclic/capabilities/livingentity/LivingEntityCapProvider.java
+++ b/src/main/java/com/lothrazar/cyclic/capabilities/livingentity/LivingEntityCapProvider.java
@@ -1,0 +1,55 @@
+package com.lothrazar.cyclic.capabilities.livingentity;
+
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.util.LazyOptional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class LivingEntityCapProvider implements ICapabilityProvider, INBTSerializable<CompoundTag> {
+
+  public static Capability<LivingEntityCapabilityStorage> CYCLIC_LIVING_ENTITY = CapabilityManager.get(new CapabilityToken<>() {});
+  private LivingEntityCapabilityStorage livingEntityAntiBeaconPosition = null;
+  private final LazyOptional<LivingEntityCapabilityStorage> opt = LazyOptional.of(this::createMe);
+
+  @Nonnull
+  private LivingEntityCapabilityStorage createMe() {
+    if (livingEntityAntiBeaconPosition == null) {
+      livingEntityAntiBeaconPosition = new LivingEntityCapabilityStorage();
+    }
+    return livingEntityAntiBeaconPosition;
+  }
+
+  @Nonnull
+  @Override
+  public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap) {
+    if (cap == CYCLIC_LIVING_ENTITY) {
+      return opt.cast();
+    }
+    return LazyOptional.empty();
+  }
+
+  @Nonnull
+  @Override
+  public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+    return getCapability(cap);
+  }
+
+  @Override
+  public CompoundTag serializeNBT() {
+    CompoundTag nbt = new CompoundTag();
+    createMe().saveNBTData(nbt);
+    return nbt;
+  }
+
+  @Override
+  public void deserializeNBT(CompoundTag nbt) {
+    createMe().loadNBTData(nbt);
+  }
+}

--- a/src/main/java/com/lothrazar/cyclic/capabilities/livingentity/LivingEntityCapabilityStorage.java
+++ b/src/main/java/com/lothrazar/cyclic/capabilities/livingentity/LivingEntityCapabilityStorage.java
@@ -1,0 +1,32 @@
+package com.lothrazar.cyclic.capabilities.livingentity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+
+public class LivingEntityCapabilityStorage {
+
+  BlockPos closestAntiBeaconPosition = null;
+
+  public LivingEntityCapabilityStorage() {}
+
+  public BlockPos getClosestAntiBeaconPosition() {
+    return closestAntiBeaconPosition;
+  }
+
+  public void setClosestAntiBeaconPosition(BlockPos closestAntiBeaconPosition) {
+    this.closestAntiBeaconPosition = closestAntiBeaconPosition;
+  }
+
+  public void saveNBTData(CompoundTag compound) {
+    if (closestAntiBeaconPosition != null) {
+      compound.put("closestAntiBeaconPosition", NbtUtils.writeBlockPos(closestAntiBeaconPosition));
+    }
+  }
+
+  public void loadNBTData(CompoundTag compound) {
+    if (compound.contains("closestAntiBeaconPosition")) {
+      closestAntiBeaconPosition = NbtUtils.readBlockPos(compound.getCompound("closestAntiBeaconPosition"));
+    }
+  }
+}

--- a/src/main/java/com/lothrazar/cyclic/registry/CapabilityRegistry.java
+++ b/src/main/java/com/lothrazar/cyclic/registry/CapabilityRegistry.java
@@ -1,10 +1,13 @@
 package com.lothrazar.cyclic.registry;
 
 import com.lothrazar.cyclic.ModCyclic;
+import com.lothrazar.cyclic.capabilities.livingentity.LivingEntityCapProvider;
+import com.lothrazar.cyclic.capabilities.livingentity.LivingEntityCapabilityStorage;
 import com.lothrazar.cyclic.capabilities.player.PlayerCapProvider;
 import com.lothrazar.cyclic.capabilities.player.PlayerCapabilityStorage;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -22,11 +25,18 @@ public class CapabilityRegistry {
         event.addCapability(new ResourceLocation(ModCyclic.MODID, "data"), new PlayerCapProvider());
       }
     }
+    if (event.getObject() instanceof LivingEntity) {
+      if (!event.getObject().getCapability(LivingEntityCapProvider.CYCLIC_LIVING_ENTITY).isPresent()) {
+        // The living entity does not already have this capability so we need to add the capability provider here
+        event.addCapability(new ResourceLocation(ModCyclic.MODID, "living_entity_data"), new LivingEntityCapProvider());
+      }
+    }
   }
 
   @SubscribeEvent
   public void onRegisterCapabilities(RegisterCapabilitiesEvent event) {
     event.register(PlayerCapabilityStorage.class);
+    event.register(LivingEntityCapabilityStorage.class);
   }
   // Finally we need to register our capability in a RegisterCapabilitiesEvent 
 }


### PR DESCRIPTION
resolves https://github.com/Lothrazar/Cyclic/issues/2269 (hopefully)

This works by having caps on living entities that the closest active anti beacon will save its own position into. Then when entities gets an effect, they only need to check the position to see if close enough, anti beacon is still there, and anti beacon is unpowered. Much much much less intensive in modpacks than block scan on every effect add (and these effect scans could load ungenerated chunks too for more lag). Many mods and datapacks expect effect add to be fast and block scans can be problematic. Some tries to add effects every few ticks to refresh the effect timer and so forth. This is when block scans can really start to add up.

We basically move the heavy lifting from entities into antibeacon and antibeacon does entity scan which is much faster than block scan too and wont load ungenerated chunks.

Also added is a check to make sure chunk is fully generated to prevent a deadlock if entity is being spawned by worldgen and given an effect right away. And I noticed the tick field in the block entity was never decremented so the effect clearing that anti beacons do wasn't actually working. 