### PR TITLE
Fix worldgen crash on 1.20

### DIFF
--- a/src/main/resources/data/cyclic/forge/biome_modifier/absalon.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/absalon.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#cyclic:has_flower/lime",
+  "features": "cyclic:flower_lime",
+  "step": "vegetal_decoration"
+}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/cyan.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/cyan.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#cyclic:has_flower/cyan",
+  "features": "cyclic:flower_cyan",
+  "step": "vegetal_decoration"
+}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/lime.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/lime.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#cyclic:has_flower/absalon",
+  "features": "cyclic:flower_absalon",
+  "step": "vegetal_decoration"
+}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_badlands.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_badlands.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_badlands",
-  "features": ["cyclic:flower_absalon","cyclic:flower_cyan"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_beach.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_beach.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_beach",
-  "features": ["cyclic:flower_cyan","cyclic:flower_purple"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_forest.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_forest.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_forest",
-  "features": ["cyclic:flower_purple"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_jungle.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_jungle.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_jungle",
-  "features": ["cyclic:flower_purple"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_mountain.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_mountain.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_mountain",
-  "features": ["cyclic:flower_cyan","cyclic:flower_lime"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_river.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_river.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_river",
-  "features": ["cyclic:flower_cyan","cyclic:flower_lime"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_savanna.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_savanna.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_savanna",
-  "features": ["cyclic:flower_absalon","cyclic:flower_lime","cyclic:flower_purple"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/modify_taiga.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/modify_taiga.json
@@ -1,6 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#minecraft:is_taiga",
-  "features": ["cyclic:flower_absalon","cyclic:flower_cyan"],
-  "step": "top_layer_modification"
-}

--- a/src/main/resources/data/cyclic/forge/biome_modifier/purple.json
+++ b/src/main/resources/data/cyclic/forge/biome_modifier/purple.json
@@ -1,0 +1,6 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#cyclic:has_flower/purple",
+  "features": "cyclic:flower_purple",
+  "step": "vegetal_decoration"
+}

--- a/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/absalon.json
+++ b/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/absalon.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#minecraft:is_badlands",
+    "#minecraft:is_savanna",
+    "#minecraft:is_taiga"
+  ]
+}

--- a/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/cyan.json
+++ b/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/cyan.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "#minecraft:is_badlands",
+    "#minecraft:is_beach",
+    "#minecraft:is_mountain",
+    "#minecraft:is_river",
+    "#minecraft:is_taiga"
+  ]
+}

--- a/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/lime.json
+++ b/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/lime.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#minecraft:is_mountain",
+    "#minecraft:is_river",
+    "#minecraft:is_savanna"
+  ]
+}

--- a/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/purple.json
+++ b/src/main/resources/data/cyclic/tags/worldgen/biome/has_flower/purple.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "#minecraft:is_beach",
+    "#minecraft:is_forest",
+    "#minecraft:is_jungle",
+    "#minecraft:is_savanna"
+  ]
+}


### PR DESCRIPTION
Closes #2394, #2388, #2377, #2371, #2364, #2354, and #2332.

## The Issue

Previously, the biome modifiers were structured so each biome tag got its own biome modifier that added a certain combination of flowers. This meant beach biomes were assigned cyan and purple flowers, badlands were assigned absalon and cyan flowers, etc.

However, issues arise when worldgen mods have biomes that fit into multiple categories. For example, a biome both tagged as a badlands biome *and* a mountain biome would get absalon flowers, cyan flowers, purple flowers, and cyan flowers... again? The game tries to maintain a consistent ordering of features to prevent generation inconsistencies, but when you have multiple of the same feature in a single biome the game can't really do that and it crashes as a result.

## The Fix

The biome modifiers have been restructured to each biome modifier controls a specific flower type, and group biome tags were added that those biome modifiers target. 

This means that instead of a `modify_forest` biome modifier telling the game to place the `flower_purple` feature in all biomes in the `#is_forest` tag, a `purple` biome modifier tells the game to place the `flower_purple` feature in all biomes in the `#cyclic:has_flower/purple` tag, which includes `#is_forest`, `#is_beach`, etc. As a result, a flower feature can never get placed twice in the same biome and no crash will occur.