### PR TITLE
Fixed Filter Data Card Issues #2423, #2370, #2355, and #2330.

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/item/datacard/filter/FilterCardItem.java
+++ b/src/main/java/com/lothrazar/cyclic/item/datacard/filter/FilterCardItem.java
@@ -118,7 +118,7 @@ public class FilterCardItem extends ItemBaseCyclic {
         if (!filterPtr.isEmpty()) {
           isEmpty = false; //at least one thing is in the filter 
           //does it match
-          if (ItemStackUtil.matches(itemTarget, filterPtr)) {
+          if (ItemStackUtil.matches(itemTarget.getItem().getDefaultInstance(), filterPtr)) {
             isMatchingList = true;
             break;
           }


### PR DESCRIPTION
#2423, #2370, #2355, and #2330

When a Filter Data Card determined if an item could be allowed/disallowed, it considered quantity rather than ignoring it.

For example, in Allow Mode, if I placed one cobblestone in the Filter Data Card, I could then place one singular cobblestone block in the chest and it would transfer. However, if I were to place more than just one cobblestone block, the filter does not recognize the stack of cobblestone in the chest as matching the one singular cobblestone block in the Data Card.

And when the Filter Data Card is on ignore mode and only one singular cobblestone block is in the filter, any cobblestone more than one singular block will be transferred anyways. 

Let me know if you have any questions!