### PR TITLE
[1.20.1] A few small bug fixes

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
+++ b/src/main/java/com/lothrazar/cyclic/block/cable/item/TileCableItem.java
@@ -80,17 +80,23 @@ public class TileCableItem extends TileCableBase implements MenuProvider {
         if (outgoingSide == incomingSide) {
           continue;
         }
-        EnumConnectType outgoingConnection = this.getBlockState().getValue(CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide));
-        if (outgoingConnection.isExtraction() || outgoingConnection.isBlocked()) {
+        if (!canPushToSide(outgoingSide)) {
           continue;
         }
         if (this.moveItems(outgoingSide, FLOW_QTY, sideHandler)) {
           continue incomingSideLoop; //if items have been moved then change side
         }
       }
-      //if no items have been moved then move items in from adjacent
-      this.moveItems(incomingSide, FLOW_QTY, sideHandler);
+      if (canPushToSide(incomingSide)) {
+        // allow items to travel backwards if they have nowhere else to go, instead of getting stuck (see #1677)
+        this.moveItems(incomingSide, FLOW_QTY, sideHandler);
+      }
     }
+  }
+
+  private boolean canPushToSide(Direction outgoingSide) {
+    EnumConnectType outgoingConnection = getBlockState().getValue(CableBase.FACING_TO_PROPERTY_MAP.get(outgoingSide));
+    return !outgoingConnection.isExtraction() && !outgoingConnection.isBlocked();
   }
 
   @Override

--- a/src/main/java/com/lothrazar/cyclic/block/collectfluid/TileFluidCollect.java
+++ b/src/main/java/com/lothrazar/cyclic/block/collectfluid/TileFluidCollect.java
@@ -12,6 +12,7 @@ import com.lothrazar.library.util.ShapeUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
@@ -201,6 +202,13 @@ public class TileFluidCollect extends TileBlockEntityCyclic implements MenuProvi
 
   @Override
   public void load(CompoundTag tag) {
+    // For backwards-compatibility: these weren't always stored, so keep the default
+    if (tag.contains("size", Tag.TAG_INT)) {
+      radius = tag.getInt("size");
+    }
+    if (tag.contains("height", Tag.TAG_INT)) {
+      height = tag.getInt("height");
+    }
     shapeIndex = tag.getInt("shapeIndex");
     tank.readFromNBT(tag.getCompound(NBTFLUID));
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
@@ -210,6 +218,8 @@ public class TileFluidCollect extends TileBlockEntityCyclic implements MenuProvi
 
   @Override
   public void saveAdditional(CompoundTag tag) {
+    tag.putInt("size", radius);
+    tag.putInt("height", height);
     tag.put(NBTENERGY, energy.serializeNBT());
     tag.put(NBTINV, inventory.serializeNBT());
     CompoundTag fluid = new CompoundTag();

--- a/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
+++ b/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
@@ -135,6 +135,7 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
     radius = tag.getInt("size");
     height = tag.getInt("height");
     isCurrentlyMining = tag.getBoolean("isCurrentlyMining");
+    shapeIndex = tag.getInt("shapeIndex");
     directionIsUp = tag.getBoolean("directionIsUp");
     energy.deserializeNBT(tag.getCompound(NBTENERGY));
     inventory.deserializeNBT(tag.getCompound(NBTINV));
@@ -146,6 +147,7 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
     tag.putInt("size", radius);
     tag.putInt("height", height);
     tag.putBoolean("isCurrentlyMining", isCurrentlyMining);
+    tag.putInt("shapeIndex", shapeIndex);
     tag.putBoolean("directionIsUp", directionIsUp);
     tag.put(NBTENERGY, energy.serializeNBT());
     tag.put(NBTINV, inventory.serializeNBT());

--- a/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
+++ b/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
@@ -208,7 +208,7 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
         if (!harvested) {
           //            world.destroyBlock(targetPos, true, fakePlayer.get());
           //removedByPlayer
-          harvested = level.getBlockState(targetPos).onDestroyedByPlayer(level, worldPosition, fakePlayer.get(), true, level.getFluidState(worldPosition));
+          harvested = level.getBlockState(targetPos).onDestroyedByPlayer(level, targetPos, fakePlayer.get(), true, level.getFluidState(targetPos));
           //   ModCyclic.LOGGER.info("Miner:removedByPlayer hacky workaround " + targetPos);
         }
         if (harvested) {

--- a/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
+++ b/src/main/java/com/lothrazar/cyclic/block/miner/TileMiner.java
@@ -12,6 +12,7 @@ import com.lothrazar.cyclic.registry.BlockRegistry;
 import com.lothrazar.cyclic.registry.ItemRegistry;
 import com.lothrazar.cyclic.registry.TileRegistry;
 import com.lothrazar.library.cap.CustomEnergyStorage;
+import net.minecraft.commands.arguments.EntityAnchorArgument;
 import com.lothrazar.library.util.ShapeUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -29,6 +30,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeConfigSpec.IntValue;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
@@ -189,7 +191,7 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
       isCurrentlyMining = true;
       //then keep current target
     }
-    else { // no valid target, back out 
+    else { // no valid target, back out
       updateTargetPos(shape);
       resetProgress();
     }
@@ -197,20 +199,22 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
     if (energy.getEnergyStored() < cost && cost > 0) {
       return false;
     }
+    FakePlayer fakePlayer = this.fakePlayer.get();
     //currentlyMining may have changed, and we are still turned on:
     if (isCurrentlyMining) {
       BlockState targetState = level.getBlockState(targetPos);
-      float relative = targetState.getDestroyProgress(fakePlayer.get(), level, targetPos);
+      float relative = targetState.getDestroyProgress(fakePlayer, level, targetPos);
       //state.getPlayerRelativeBlockHardness(player, worldIn, pos);UtilItemStack.getPlayerRelativeBlockHardness(targetState.getBlock(), targetState, fakePlayer.get(), world, targetPos);
       curBlockDamage += relative;
       //
       //if hardness is relative, jus fekin break it like air eh
       if (curBlockDamage >= 1.0f || relative == 0) {
-        boolean harvested = fakePlayer.get().gameMode.destroyBlock(targetPos);
+        placePlayerBehindBlock(fakePlayer, targetPos);
+        boolean harvested = fakePlayer.gameMode.destroyBlock(targetPos);
         if (!harvested) {
           //            world.destroyBlock(targetPos, true, fakePlayer.get());
           //removedByPlayer
-          harvested = level.getBlockState(targetPos).onDestroyedByPlayer(level, targetPos, fakePlayer.get(), true, level.getFluidState(targetPos));
+          harvested = level.getBlockState(targetPos).onDestroyedByPlayer(level, targetPos, fakePlayer, true, level.getFluidState(targetPos));
           //   ModCyclic.LOGGER.info("Miner:removedByPlayer hacky workaround " + targetPos);
         }
         if (harvested) {
@@ -219,14 +223,26 @@ public class TileMiner extends TileBlockEntityCyclic implements MenuProvider {
           resetProgress();
         }
         else {
-          level.destroyBlockProgress(fakePlayer.get().getUUID().hashCode(), targetPos, (int) (curBlockDamage * 10.0F) - 1);
+          level.destroyBlockProgress(fakePlayer.getUUID().hashCode(), targetPos, (int) (curBlockDamage * 10.0F) - 1);
         }
       }
     }
-    else { //is mining is false 
-      level.destroyBlockProgress(fakePlayer.get().getUUID().hashCode(), targetPos, (int) (curBlockDamage * 10.0F) - 1);
+    else { //is mining is false
+      level.destroyBlockProgress(fakePlayer.getUUID().hashCode(), targetPos, (int) (curBlockDamage * 10.0F) - 1);
     }
     return false;
+  }
+
+  private void placePlayerBehindBlock(FakePlayer player, BlockPos targetPos) {
+    // Some items (such as Mattock) use the position of the player relative to the block to determine mining behavior
+    // Place the fake player just behind the block
+    Direction facing = getBlockState().getValue(BlockStateProperties.FACING);
+    player.moveTo(
+        targetPos.getX() - facing.getStepX() + 0.5,
+        targetPos.getY() - facing.getStepY() + 0.5 - player.getEyeHeight(),
+        targetPos.getZ() - facing.getStepZ() + 0.5
+    );
+    player.lookAt(EntityAnchorArgument.Anchor.EYES, Vec3.atCenterOf(targetPos));
   }
 
   /***

--- a/src/main/java/com/lothrazar/cyclic/block/shapedata/RenderShapedata.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapedata/RenderShapedata.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
 
 public class RenderShapedata implements BlockEntityRenderer<TileShapedata> {
@@ -16,18 +17,26 @@ public class RenderShapedata implements BlockEntityRenderer<TileShapedata> {
   @Override
   public void render(TileShapedata te, float v, PoseStack matrixStack, MultiBufferSource ibuffer, int partialTicks, int destroyStage) {
     int previewType = te.getField(TileShapedata.Fields.RENDER.ordinal());
+    if (PreviewOutlineType.NONE.ordinal() == previewType) {
+      return;
+    }
+    BlockPos targetA = te.getTarget(0);
+    BlockPos targetB = te.getTarget(1);
     if (PreviewOutlineType.SHADOW.ordinal() == previewType) {
-      if (te.getTarget(0) != null) {
-        RenderBlockUtils.renderOutline(te.getBlockPos(), te.getTarget(0), matrixStack, 1.05F, Color.BLUE);
+      if (targetA != null) {
+        RenderBlockUtils.renderOutline(te.getBlockPos(), targetA, matrixStack, 1.05F, Color.BLUE);
       }
-      if (te.getTarget(1) != null) {
-        RenderBlockUtils.renderOutline(te.getBlockPos(), te.getTarget(1), matrixStack, 1.05F, Color.RED);
+      if (targetB != null) {
+        RenderBlockUtils.renderOutline(te.getBlockPos(), targetB, matrixStack, 1.05F, Color.RED);
       }
     }
     else if (PreviewOutlineType.WIREFRAME.ordinal() == previewType) {
-      //      for (BlockPos crd : te.getShapeHollow()) {
-      RenderBlockUtils.createBox(matrixStack, te.getTarget(0), Vec3.atLowerCornerOf(te.getBlockPos()));
-      RenderBlockUtils.createBox(matrixStack, te.getTarget(1), Vec3.atLowerCornerOf(te.getBlockPos()));
+      if (targetA != null) {
+        RenderBlockUtils.createBox(matrixStack, targetA, Vec3.atLowerCornerOf(te.getBlockPos()));
+      }
+      if (targetB != null) {
+        RenderBlockUtils.createBox(matrixStack, targetB, Vec3.atLowerCornerOf(te.getBlockPos()));
+      }
     }
   }
 }

--- a/src/main/java/com/lothrazar/cyclic/block/shapedata/TileShapedata.java
+++ b/src/main/java/com/lothrazar/cyclic/block/shapedata/TileShapedata.java
@@ -1,6 +1,7 @@
 package com.lothrazar.cyclic.block.shapedata;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import com.lothrazar.cyclic.ModCyclic;
 import com.lothrazar.cyclic.block.TileBlockEntityCyclic;
 import com.lothrazar.cyclic.data.PreviewOutlineType;
@@ -214,6 +215,7 @@ public class TileShapedata extends TileBlockEntityCyclic implements MenuProvider
     return true;
   }
 
+  @Nullable
   public BlockPos getTarget(int s) {
     ItemStack stackA = inventory.getStackInSlot(s);
     BlockPosDim loc = LocationGpsCard.getPosition(stackA);


### PR DESCRIPTION
This PR is a collection of a few small but random fixes to bugs we noticed while playing with Cyclic on a server - I thought it makes more sense to just make one PR than a bunch of tiny ones, but happy to split it up if that is preferred! 

Particularly, the last commit addresses an inconsistency with Mattocks in Miners - but I'm not sure how it is supposed to behave by design. If this needs some more thought especially, I can move that out or drop the commit :slightly_smiling_face: 

Also not sure if the 1.20.1 branch is the right one to PR to - but if not, am happy to rebase it :) 

The bugs addressed:
* If a Miner fails to harvest a block (in our case, mining an instanced loot chest from Lootr), it would destroy itself. This seems to have been a mistake in the fallback case when the target fails to be mined, forcing the break on itself rather than the target. Might relate to #2367? 
* Fluid Collectors when unloaded would lose their size/height settings (unlike Miners)
* Miners when unloaded would lose their current mined progress (unlike Fluid Collectors)
* The client would crash when trying to render a shapedata block preview without both targets set
* Items in cables could be pushed against an extraction cable in the fallback case where they could not travel anywhere else - this could rarely lead to output items ending up back in input slots in an unexpected way
* Mattocks behave inconsistently when used in a Miner block - as the fake player is placed at the corner of the Miner, the distance and whether in the negative/negative quadrant relative to the Miner would affect whether it applies