### PR TITLE
Change leaves sythe description to use the right tag 

### DIFF
--- a/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/src/main/resources/assets/cyclic/lang/en_us.json
@@ -962,7 +962,7 @@
   "item.cyclic.scythe_forage.guide": "Forage growing resources, using the following block data tags:  minecraft:flowers, minecraft:corals, forge:mushrooms, forge:vines, forge:cactus, forge:crop_blocks",
   "item.cyclic.scythe_leaves": "Tree Scythe",
   "item.cyclic.scythe_leaves.tooltip": "Mass leaf removal",
-  "item.cyclic.scythe_leaves.guide": "Harvests all nearby leaves on use, using the forge:leaves block data tag",
+  "item.cyclic.scythe_leaves.guide": "Harvests all nearby leaves on use, using the minecraft:leaves block data tag",
   "item.cyclic.scythe_brush": "Brush Scythe",
   "item.cyclic.scythe_brush.tooltip": "Harvest weeds based on data tag.",
   "item.cyclic.scythe_brush.guide": "Harvest everything under the block data tag forge:plants.",

--- a/src/main/resources/assets/cyclic/lang/ko_kr.json
+++ b/src/main/resources/assets/cyclic/lang/ko_kr.json
@@ -922,7 +922,7 @@
     "item.cyclic.scythe_forage.guide": "다음 블록 데이터 태그를 쓰는, 자라는 자원을 채집합니다:  minecraft:flowers, minecraft:corals, forge:mushrooms, forge:vines, forge:cactus, forge:crop_blocks",
     "item.cyclic.scythe_leaves": "나무 낫",
     "item.cyclic.scythe_leaves.tooltip": "잎 대량 제거",
-    "item.cyclic.scythe_leaves.guide": "사용 시 forge:leaves 블록 데이터 태그를 사용하는 근처의 모든 잎을 수확합니다.",
+    "item.cyclic.scythe_leaves.guide": "사용 시 minecraft:leaves 블록 데이터 태그를 사용하는 근처의 모든 잎을 수확합니다.",
     "item.cyclic.scythe_brush": "수풀 낫",
     "item.cyclic.scythe_brush.tooltip": "데이터 태그에 기반하여 잡초를 수확합니다",
     "item.cyclic.scythe_brush.guide": "블록 데이터 태그 forge:plants가 달린 모든 것을 수확합니다.",


### PR DESCRIPTION
Description was incorrect, it uses a vanilla tag ([source](https://github.com/Lothrazar/Cyclic/blob/1fa2696be3109e16c9b70fac5887ec26293c2700/src/main/java/com/lothrazar/cyclic/util/HarvestUtil.java#L49))