### PR TITLE
Fix #2497: Disable Multi-Jump for all vehicles

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/enchant/MultiJumpEnchant.java
+++ b/src/main/java/com/lothrazar/cyclic/enchant/MultiJumpEnchant.java
@@ -110,7 +110,7 @@ public class MultiJumpEnchant extends EnchantmentFlib {
   }
 
   public void onKeyInput(Player player) {
-    if (player == null || player.getVehicle() instanceof Boat) {
+    if (player == null || player.getVehicle() != null) {
       return;
     }
     ItemStack feet = getFirstArmorStackWithEnchant(player);


### PR DESCRIPTION
Fixes #2497 - Multi-Jump now disables for all vehicles, not just boats.