### PR TITLE
fix java.lang.IllegalArgumentException: Modifier is already applied on this attribute!

### DIFF
--- a/src/main/java/com/lothrazar/cyclic/event/ItemEventHandler.java
+++ b/src/main/java/com/lothrazar/cyclic/event/ItemEventHandler.java
@@ -321,7 +321,9 @@ public class ItemEventHandler {
     if (original != null) {
       AttributeModifier healthModifier = original.getModifier(AttributesUtil.DEFAULT_ID);
       if (healthModifier != null) {
-        event.getEntity().getAttribute(Attributes.MAX_HEALTH).addPermanentModifier(healthModifier);
+        AttributeInstance newAttribute = event.getEntity().getAttribute(Attributes.MAX_HEALTH);
+        newAttribute.removeModifier(AttributesUtil.DEFAULT_ID);
+        newAttribute.addPermanentModifier(healthModifier);
       }
     }
   }


### PR DESCRIPTION
This error occurs when a player presses the main menu and the second time presses revive, he can no longer revive.